### PR TITLE
Vercel-style docs: rewrite, hierarchy, color unification

### DIFF
--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,3 +1,5 @@
+import { Callout } from "@/components/callout";
+import { DocPlaceholder } from "@/components/doc-placeholder";
 import { transformerColorizedBrackets } from "@shikijs/colorized-brackets";
 import type { MDXComponents } from "mdx/types";
 import Image from "next/image";
@@ -172,6 +174,8 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
         {children}
       </td>
     ),
+    Callout,
+    DocPlaceholder,
     ...components,
   };
 }

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -64,7 +64,16 @@ async function CodeBlock({ code, lang }: { code: string; lang: string }) {
     ],
   });
 
-  return <div className="min-w-0 max-w-full w-full my-6 [&>pre]:overflow-x-auto [&>pre]:p-4 [&>pre]:rounded-lg" dangerouslySetInnerHTML={{ __html: out }} />;
+  return (
+    <div
+      // Shiki's inline style on the rendered <pre> is whitespace-normalized
+      // differently between SSR (no space after ":") and the browser (which
+      // re-serializes with a space). Visually identical, so suppress.
+      suppressHydrationWarning
+      className="min-w-0 max-w-full w-full my-6 [&>pre]:overflow-x-auto [&>pre]:p-4 [&>pre]:rounded-lg"
+      dangerouslySetInnerHTML={{ __html: out }}
+    />
+  );
 }
 
 const IMAGE_DIMENSION_REGEX = /^[^|]+\|\d+x\d+$/;

--- a/public/docs/PLACEHOLDER-CHECKLIST.md
+++ b/public/docs/PLACEHOLDER-CHECKLIST.md
@@ -1,0 +1,178 @@
+# Doc Placeholder Media Checklist
+
+This is the master list of screenshots, videos, and diagrams referenced via
+`<DocPlaceholder>` in the docs MDX. Each entry shows the eventual path under
+`public/`, the MDX page that uses it, and what the asset should contain.
+
+When an asset is captured, drop it at the listed path and replace the
+`<DocPlaceholder>` in the MDX with a normal `<Image>`, `<Video>`, or `<img>` tag
+that points at the same path. The placeholder rendering goes away automatically.
+
+## Conventions
+
+- **Screenshots**: PNG, 16:9 (e.g. 1280×720 or 1920×1080), light theme by default.
+  For UI surfaces that have meaningful dark theming, add a `-dark` variant at
+  the same path with the suffix.
+- **Videos**: MP4, H.264, 1280×720 or 1920×1080, with audio muted. Aim for
+  30–60 seconds. Ship a `-poster.png` at the same path stem.
+- **Diagrams**: SVG preferred, otherwise PNG at 1280×720+.
+- **Annotations**: when "annotated" appears in the description, overlay numbered
+  callouts (①, ②, ③) and pair with a short on-page legend or alt text.
+
+## Capture environment
+
+- Use a clean staging practice in the live product (not production).
+- Use realistic but obviously-test client names (e.g. "Acme Demo Client",
+  "Test Matter").
+- Strip any PII before the file is committed.
+
+## Asset list
+
+### Onboarding / get-started
+
+- [ ] `public/docs/onboarding/conversational-setup.mp4` — used by
+  `src/data/docs/quick-start/create-practice-account.mdx`. 60-second walkthrough
+  of `PracticeOnboardingPage` — the AI asks for the firm name, slug, accent
+  color, contact info, services, and team.
+- [ ] `public/docs/onboarding/dashboard-after-setup.png` — used by
+  `src/data/docs/quick-start/create-practice-account.mdx`. Dashboard after
+  first-time onboarding — intake queue, summary cards, quick-action buttons,
+  notification bell.
+
+### Payments
+
+- [ ] `public/docs/payments/stripe-connect.mp4` — used by
+  `src/data/docs/quick-start/accept-first-payment.mdx`. 60-second walkthrough
+  of the two Stripe Connect checkpoints — link bank, enable charges — followed
+  by sending the first invoice.
+- [ ] `public/docs/payments/stripe-checkpoints.png` — used by
+  `src/data/docs/quick-start/accept-first-payment.mdx`. Stripe checkpoint card
+  in Settings → Payments — checkpoint 1 (Linked), checkpoint 2 (Charges
+  enabled).
+- [ ] `public/docs/payments/first-invoice.png` — used by
+  `src/data/docs/quick-start/accept-first-payment.mdx`. A draft invoice
+  generated from unbilled time, with line items pulled from time entries and
+  the Send button highlighted.
+
+### Intake
+
+- [ ] `public/docs/intake/template-walkthrough.mp4` — used by
+  `src/data/docs/features/intake-templates.mdx`. 30-second walkthrough of
+  `IntakeTemplatesPage` — creating a template, adding a required field, adding
+  an enrichment field, toggling consultation fee.
+- [ ] `public/docs/intake/field-editor-annotated.png` — used by
+  `src/data/docs/features/intake-templates.mdx`. Annotated `IntakeTemplatesPage`
+  field editor with ① required toggle, ② enrichment toggle, ③ conditional
+  `dependsOn` selector.
+- [ ] `public/docs/intake/payment-card-in-chat.png` — used by
+  `src/data/docs/features/intake-templates.mdx`. Stripe Elements payment card
+  in the chat thread, between contact collection and submission confirmation.
+- [ ] `public/docs/intake/template-list.png` — used by
+  `src/data/docs/features/set-up-client-intake.mdx`. `IntakeTemplatesPage` list
+  view, with one default template and the New template CTA visible.
+- [ ] `public/docs/intake/queue.png` — used by
+  `src/data/docs/features/review-and-triage-intake.mdx`. `IntakesPage` queue
+  with several submissions, urgency badges, and the New filter active.
+- [ ] `public/docs/intake/detail-page-annotated.png` — used by
+  `src/data/docs/features/review-and-triage-intake.mdx`. `IntakeDetailPage`
+  with the case summary, urgency badge, custom fields, and decision buttons
+  annotated.
+- [ ] `public/docs/intake/four-stage-flow.png` — used by
+  `src/data/solutions/ai-chat/modern-intake-flow.mdx`. Annotated chat
+  screenshot showing all four stages — engagement, trust building,
+  qualification, authentication + fee — in one continuous thread.
+
+### Chat / conversations
+
+- [ ] `public/docs/chat/conversation-walkthrough.mp4` — used by
+  `src/data/docs/features/join-client-conversation.mdx`. 60-second walkthrough
+  of an active conversation — sending a message, attaching a file, the AI
+  surfacing a quick-reply suggestion, and paralegal analysis streaming in.
+- [ ] `public/docs/chat/paralegal-analysis-stream.png` — used by
+  `src/data/docs/features/join-client-conversation.mdx`. Paralegal AI streaming
+  analysis in the conversation thread — file uploaded, status messages,
+  extracted facts inline.
+
+### Matters
+
+- [ ] `public/docs/matters/walkthrough.mp4` — used by
+  `src/data/docs/features/matters-overview.mdx`. 45-second walkthrough of the
+  matter detail panel — opening a matter, adding a time entry, generating an
+  invoice from unbilled time.
+- [ ] `public/docs/matters/tabs-annotated.png` — used by
+  `src/data/docs/features/matters-overview.mdx`. Annotated `MatterDetailPanel`
+  showing the seven tabs (Overview, Work, Billing, Files, Notes, Activity,
+  Settings).
+- [ ] `public/docs/matters/billing-unbilled-summary.png` — used by
+  `src/data/docs/features/matters-overview.mdx`. Billing tab with the unbilled
+  summary card highlighted and the "Generate invoice" CTA visible.
+- [ ] `public/docs/matters/time-entry-form.png` — used by
+  `src/data/docs/features/manage-matters.mdx`. Time entry form on the Work tab
+  — start/end pickers, description, billable toggle, rate auto-applied from
+  user role.
+
+### Engagements
+
+- [ ] `public/docs/engagements/walkthrough.mp4` — used by
+  `src/data/docs/features/engagements-overview.mdx`. 60-second walkthrough of
+  creating an engagement from a matter — Blawby pre-fills the four sections,
+  attorney edits, sends, client signs.
+- [ ] `public/docs/engagements/representation-section.png` — used by
+  `src/data/docs/features/engagements-overview.mdx`. Representation section
+  with included and excluded services rendered side-by-side.
+- [ ] `public/docs/engagements/client-review-page.png` — used by
+  `src/data/docs/features/engagements-overview.mdx`. `ClientEngagementReviewPage`
+  with sections collapsed and the sign button at the bottom.
+- [ ] `public/docs/engagements/draft-editor.png` — used by
+  `src/data/docs/features/send-engagement-and-collect-payment.mdx`. Engagement
+  draft editor with the four sections expanded — representation, fees, risk
+  review, acknowledgments.
+- [ ] `public/docs/engagements/client-acceptance.mp4` — used by
+  `src/data/docs/features/send-engagement-and-collect-payment.mdx`. Client
+  opens the engagement, reviews the four sections, signs, and is redirected to
+  Stripe for retainer payment.
+
+### Billing
+
+- [ ] `public/docs/billing/generate-invoice.png` — used by
+  `src/data/lessons/invoicing.mdx`. Billing tab on a matter — unbilled summary
+  expanded, Generate invoice CTA highlighted, draft preview to the right.
+
+### AI chat strategy / diagrams
+
+- [ ] `public/docs/ai-chat/intent-routing.svg` — used by
+  `src/data/solutions/ai-chat/ai-chat-client-acquisition.mdx`. Diagram of the
+  intent classifier — first message routes to `REQUEST_CONSULTATION`,
+  `ASK_QUESTION`, or `CONVERSATION` based on signal. **Designer asset** — best
+  shipped as SVG, not a screenshot.
+
+### Reference / API
+
+- [ ] `public/docs/reference/api-surface-diagram.svg` — used by
+  `src/data/docs/reference/api-reference.mdx`. Future API surface — embeddable
+  widget on the left, public REST API in the middle, your service on the
+  right. **Designer asset.**
+
+## Workflow
+
+1. Pick an asset from the list above.
+2. Capture it in the staging environment.
+3. Drop the file at the listed path under `public/docs/`.
+4. Open the MDX file that references it.
+5. Replace the `<DocPlaceholder ... />` block with a real tag — for screenshots:
+
+   ```mdx
+   ![Description of screenshot|1280x720](/docs/intake/queue.png)
+   ```
+
+   For videos:
+
+   ```mdx
+   <Video
+     src="/docs/intake/template-walkthrough.mp4"
+     poster="/docs/intake/template-walkthrough-poster.png"
+   />
+   ```
+
+6. Check the box above.
+7. Commit with a message like `docs: add real screenshot for intake queue`.

--- a/public/media/docs/PLACEHOLDER-CHECKLIST.md
+++ b/public/media/docs/PLACEHOLDER-CHECKLIST.md
@@ -30,117 +30,117 @@ that points at the same path. The placeholder rendering goes away automatically.
 
 ### Onboarding / get-started
 
-- [ ] `public/docs/onboarding/conversational-setup.mp4` — used by
+- [ ] `public/media/media/docs/onboarding/conversational-setup.mp4` — used by
   `src/data/docs/quick-start/create-practice-account.mdx`. 60-second walkthrough
   of `PracticeOnboardingPage` — the AI asks for the firm name, slug, accent
   color, contact info, services, and team.
-- [ ] `public/docs/onboarding/dashboard-after-setup.png` — used by
+- [ ] `public/media/media/docs/onboarding/dashboard-after-setup.png` — used by
   `src/data/docs/quick-start/create-practice-account.mdx`. Dashboard after
   first-time onboarding — intake queue, summary cards, quick-action buttons,
   notification bell.
 
 ### Payments
 
-- [ ] `public/docs/payments/stripe-connect.mp4` — used by
+- [ ] `public/media/media/docs/payments/stripe-connect.mp4` — used by
   `src/data/docs/quick-start/accept-first-payment.mdx`. 60-second walkthrough
   of the two Stripe Connect checkpoints — link bank, enable charges — followed
   by sending the first invoice.
-- [ ] `public/docs/payments/stripe-checkpoints.png` — used by
+- [ ] `public/media/media/docs/payments/stripe-checkpoints.png` — used by
   `src/data/docs/quick-start/accept-first-payment.mdx`. Stripe checkpoint card
   in Settings → Payments — checkpoint 1 (Linked), checkpoint 2 (Charges
   enabled).
-- [ ] `public/docs/payments/first-invoice.png` — used by
+- [ ] `public/media/media/docs/payments/first-invoice.png` — used by
   `src/data/docs/quick-start/accept-first-payment.mdx`. A draft invoice
   generated from unbilled time, with line items pulled from time entries and
   the Send button highlighted.
 
 ### Intake
 
-- [ ] `public/docs/intake/template-walkthrough.mp4` — used by
+- [ ] `public/media/media/docs/intake/template-walkthrough.mp4` — used by
   `src/data/docs/features/intake-templates.mdx`. 30-second walkthrough of
   `IntakeTemplatesPage` — creating a template, adding a required field, adding
   an enrichment field, toggling consultation fee.
-- [ ] `public/docs/intake/field-editor-annotated.png` — used by
+- [ ] `public/media/media/docs/intake/field-editor-annotated.png` — used by
   `src/data/docs/features/intake-templates.mdx`. Annotated `IntakeTemplatesPage`
   field editor with ① required toggle, ② enrichment toggle, ③ conditional
   `dependsOn` selector.
-- [ ] `public/docs/intake/payment-card-in-chat.png` — used by
+- [ ] `public/media/media/docs/intake/payment-card-in-chat.png` — used by
   `src/data/docs/features/intake-templates.mdx`. Stripe Elements payment card
   in the chat thread, between contact collection and submission confirmation.
-- [ ] `public/docs/intake/template-list.png` — used by
+- [ ] `public/media/media/docs/intake/template-list.png` — used by
   `src/data/docs/features/set-up-client-intake.mdx`. `IntakeTemplatesPage` list
   view, with one default template and the New template CTA visible.
-- [ ] `public/docs/intake/queue.png` — used by
+- [ ] `public/media/media/docs/intake/queue.png` — used by
   `src/data/docs/features/review-and-triage-intake.mdx`. `IntakesPage` queue
   with several submissions, urgency badges, and the New filter active.
-- [ ] `public/docs/intake/detail-page-annotated.png` — used by
+- [ ] `public/media/media/docs/intake/detail-page-annotated.png` — used by
   `src/data/docs/features/review-and-triage-intake.mdx`. `IntakeDetailPage`
   with the case summary, urgency badge, custom fields, and decision buttons
   annotated.
-- [ ] `public/docs/intake/four-stage-flow.png` — used by
+- [ ] `public/media/media/docs/intake/four-stage-flow.png` — used by
   `src/data/solutions/ai-chat/modern-intake-flow.mdx`. Annotated chat
   screenshot showing all four stages — engagement, trust building,
   qualification, authentication + fee — in one continuous thread.
 
 ### Chat / conversations
 
-- [ ] `public/docs/chat/conversation-walkthrough.mp4` — used by
+- [ ] `public/media/media/docs/chat/conversation-walkthrough.mp4` — used by
   `src/data/docs/features/join-client-conversation.mdx`. 60-second walkthrough
   of an active conversation — sending a message, attaching a file, the AI
   surfacing a quick-reply suggestion, and paralegal analysis streaming in.
-- [ ] `public/docs/chat/paralegal-analysis-stream.png` — used by
+- [ ] `public/media/media/docs/chat/paralegal-analysis-stream.png` — used by
   `src/data/docs/features/join-client-conversation.mdx`. Paralegal AI streaming
   analysis in the conversation thread — file uploaded, status messages,
   extracted facts inline.
 
 ### Matters
 
-- [ ] `public/docs/matters/walkthrough.mp4` — used by
+- [ ] `public/media/media/docs/matters/walkthrough.mp4` — used by
   `src/data/docs/features/matters-overview.mdx`. 45-second walkthrough of the
   matter detail panel — opening a matter, adding a time entry, generating an
   invoice from unbilled time.
-- [ ] `public/docs/matters/tabs-annotated.png` — used by
+- [ ] `public/media/media/docs/matters/tabs-annotated.png` — used by
   `src/data/docs/features/matters-overview.mdx`. Annotated `MatterDetailPanel`
   showing the seven tabs (Overview, Work, Billing, Files, Notes, Activity,
   Settings).
-- [ ] `public/docs/matters/billing-unbilled-summary.png` — used by
+- [ ] `public/media/media/docs/matters/billing-unbilled-summary.png` — used by
   `src/data/docs/features/matters-overview.mdx`. Billing tab with the unbilled
   summary card highlighted and the "Generate invoice" CTA visible.
-- [ ] `public/docs/matters/time-entry-form.png` — used by
+- [ ] `public/media/media/docs/matters/time-entry-form.png` — used by
   `src/data/docs/features/manage-matters.mdx`. Time entry form on the Work tab
   — start/end pickers, description, billable toggle, rate auto-applied from
   user role.
 
 ### Engagements
 
-- [ ] `public/docs/engagements/walkthrough.mp4` — used by
+- [ ] `public/media/media/docs/engagements/walkthrough.mp4` — used by
   `src/data/docs/features/engagements-overview.mdx`. 60-second walkthrough of
   creating an engagement from a matter — Blawby pre-fills the four sections,
   attorney edits, sends, client signs.
-- [ ] `public/docs/engagements/representation-section.png` — used by
+- [ ] `public/media/media/docs/engagements/representation-section.png` — used by
   `src/data/docs/features/engagements-overview.mdx`. Representation section
   with included and excluded services rendered side-by-side.
-- [ ] `public/docs/engagements/client-review-page.png` — used by
+- [ ] `public/media/media/docs/engagements/client-review-page.png` — used by
   `src/data/docs/features/engagements-overview.mdx`. `ClientEngagementReviewPage`
   with sections collapsed and the sign button at the bottom.
-- [ ] `public/docs/engagements/draft-editor.png` — used by
+- [ ] `public/media/media/docs/engagements/draft-editor.png` — used by
   `src/data/docs/features/send-engagement-and-collect-payment.mdx`. Engagement
   draft editor with the four sections expanded — representation, fees, risk
   review, acknowledgments.
-- [ ] `public/docs/engagements/client-acceptance.mp4` — used by
+- [ ] `public/media/media/docs/engagements/client-acceptance.mp4` — used by
   `src/data/docs/features/send-engagement-and-collect-payment.mdx`. Client
   opens the engagement, reviews the four sections, signs, and is redirected to
   Stripe for retainer payment.
 
 ### Billing
 
-- [ ] `public/docs/billing/generate-invoice.png` — used by
+- [ ] `public/media/media/docs/billing/generate-invoice.png` — used by
   `src/data/lessons/invoicing.mdx`. Billing tab on a matter — unbilled summary
   expanded, Generate invoice CTA highlighted, draft preview to the right.
 
 ### AI chat strategy / diagrams
 
-- [ ] `public/docs/ai-chat/intent-routing.svg` — used by
+- [ ] `public/media/media/docs/ai-chat/intent-routing.svg` — used by
   `src/data/solutions/ai-chat/ai-chat-client-acquisition.mdx`. Diagram of the
   intent classifier — first message routes to `REQUEST_CONSULTATION`,
   `ASK_QUESTION`, or `CONVERSATION` based on signal. **Designer asset** — best
@@ -148,8 +148,8 @@ that points at the same path. The placeholder rendering goes away automatically.
 
 ### Reference / API
 
-- [ ] `public/docs/reference/api-surface-diagram.svg` — used by
-  `src/data/docs/reference/api-reference.mdx`. Future API surface — embeddable
+- [ ] `public/media/media/docs/reference/api-surface-diagram.svg` — used by
+  `src/data/media/docs/reference/api-reference.mdx`. Future API surface — embeddable
   widget on the left, public REST API in the middle, your service on the
   right. **Designer asset.**
 
@@ -157,20 +157,20 @@ that points at the same path. The placeholder rendering goes away automatically.
 
 1. Pick an asset from the list above.
 2. Capture it in the staging environment.
-3. Drop the file at the listed path under `public/docs/`.
+3. Drop the file at the listed path under `public/media/docs/`.
 4. Open the MDX file that references it.
 5. Replace the `<DocPlaceholder ... />` block with a real tag — for screenshots:
 
    ```mdx
-   ![Description of screenshot|1280x720](/docs/intake/queue.png)
+   ![Description of screenshot|1280x720](/media/docs/intake/queue.png)
    ```
 
    For videos:
 
    ```mdx
    <Video
-     src="/docs/intake/template-walkthrough.mp4"
-     poster="/docs/intake/template-walkthrough-poster.png"
+     src="/media/docs/intake/template-walkthrough.mp4"
+     poster="/media/docs/intake/template-walkthrough-poster.png"
    />
    ```
 

--- a/src/app/(sidebar)/[category]/[slug]/page.tsx
+++ b/src/app/(sidebar)/[category]/[slug]/page.tsx
@@ -217,6 +217,20 @@ export default async function Page({
           <div id="content" className="prose">
             <Content />
           </div>
+          {content.lastVerified && (
+            <p className="mt-10 border-t border-gray-200 pt-4 text-xs text-gray-500 dark:border-white/10 dark:text-gray-400">
+              Last verified against the live product on{" "}
+              <time dateTime={content.lastVerified}>
+                {new Date(content.lastVerified).toLocaleDateString("en-US", {
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric",
+                  timeZone: "UTC",
+                })}
+              </time>
+              .
+            </p>
+          )}
         </div>
         <div className="hidden w-66 lg:block">
           <TableOfContents contentId="content" />

--- a/src/app/(sidebar)/[category]/[slug]/page.tsx
+++ b/src/app/(sidebar)/[category]/[slug]/page.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/components/breadcrumbs";
 import { NextPageLink } from "@/components/next-page-link";
 import { SidebarLayoutContent } from "@/components/sidebar-layout";
+import { formatSectionLabel } from "@/utils/section-label";
 import TableOfContents from "@/components/table-of-contents";
 import { Video } from "@/components/video-player";
 import { siteConfig } from "@/config/site";
@@ -25,6 +26,7 @@ import fs from "fs";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import path from "path";
+import { Fragment } from "react";
 function escapeJsonLd(data: unknown) {
   if (data === null || data === undefined) return "";
   return JSON.stringify(data).replace(/</g, "\\u003c");
@@ -108,18 +110,50 @@ export default async function Page({
   const lessonData = isLesson ? await getLesson(slug) : null;
   const structuredData = generateContentStructuredData(content);
 
-  // Backlink: lessons → /products, docs → /docs, articles → /solutions
-  const parentLink =
-    content.origin === "lessons"
-      ? { label: "Products", href: "/products" }
-      : content.origin === "docs"
-      ? { label: "Docs", href: "/docs" }
-      : { label: "Solutions", href: "/solutions" };
+  // Origin → its real landing page route. Used as the deepest *linked* node
+  // in the breadcrumb trail; the label between it and the page title comes
+  // from frontmatter (group → category) so we never hardcode IA names.
+  const ORIGIN_LANDING: Record<string, { label: string; href: string }> = {
+    lessons: { label: "Products", href: "/products" },
+    docs: { label: "Docs", href: "/docs" },
+    solutions: { label: "Solutions", href: "/solutions" },
+    articles: { label: "Solutions", href: "/solutions" },
+  };
+  const originLanding =
+    ORIGIN_LANDING[content.origin] ?? {
+      label: formatSectionLabel(content.origin),
+      href: `/${content.origin}`,
+    };
+
+  // Build the trail dynamically from the content's own metadata:
+  //   Home > {Origin landing} > {Category} > [{Group}] > {Page title}
+  // The category step is skipped when it would duplicate the origin label
+  // (e.g. solutions content where origin=solutions and category=solutions).
+  const categoryLabel = formatSectionLabel(content.category);
+  const breadcrumbTrail: Array<{
+    name: string;
+    href?: string;
+  }> = [{ name: originLanding.label, href: originLanding.href }];
+
+  if (
+    categoryLabel.toLowerCase() !== originLanding.label.toLowerCase() &&
+    content.category.toLowerCase() !== content.origin.toLowerCase()
+  ) {
+    breadcrumbTrail.push({ name: categoryLabel });
+  }
+
+  if (content.group) {
+    breadcrumbTrail.push({ name: content.group });
+  }
+
+  breadcrumbTrail.push({ name: content.title || "" });
 
   const breadcrumbItems = [
     { name: "Home", url: absoluteUrl() },
-    { name: parentLink.label, url: absoluteUrl(parentLink.href) },
-    { name: content.title || "", url: absoluteUrl(content.href) },
+    ...breadcrumbTrail.map((step) => ({
+      name: step.name,
+      url: step.href ? absoluteUrl(step.href) : absoluteUrl(content.href),
+    })),
   ];
   const breadcrumbSchema = getBreadcrumbSchema(breadcrumbItems);
 
@@ -181,10 +215,16 @@ export default async function Page({
       breadcrumbs={
         <Breadcrumbs>
           <BreadcrumbHome />
-          <BreadcrumbSeparator />
-          <Breadcrumb href={parentLink.href}>{parentLink.label}</Breadcrumb>
-          <BreadcrumbSeparator />
-          <Breadcrumb>{content.title}</Breadcrumb>
+          {breadcrumbTrail.map((step, idx) => (
+            <Fragment key={`${idx}-${step.name}`}>
+              <BreadcrumbSeparator />
+              {step.href ? (
+                <Breadcrumb href={step.href}>{step.name}</Breadcrumb>
+              ) : (
+                <Breadcrumb>{step.name}</Breadcrumb>
+              )}
+            </Fragment>
+          ))}
         </Breadcrumbs>
       }
     >
@@ -212,14 +252,17 @@ export default async function Page({
       )}
 
       {/* Content area */}
-      <div className="mx-auto flex max-w-2xl gap-x-10 py-10 sm:py-14 lg:max-w-5xl">
+      <div className="mx-auto flex max-w-2xl gap-x-10 pt-6 pb-10 sm:pt-8 sm:pb-14 lg:max-w-5xl">
         <div className="w-full flex-1">
-          <div id="content" className="prose">
-            <Content />
-          </div>
           {content.lastVerified && (
-            <p className="mt-10 border-t border-gray-200 pt-4 text-xs text-gray-500 dark:border-white/10 dark:text-gray-400">
-              Last verified against the live product on{" "}
+            <p
+              className={
+                "mb-6 flex flex-wrap items-center justify-end gap-2 " +
+                "border-b border-gray-200 pb-4 text-sm text-gray-700 " +
+                "dark:border-white/10 dark:text-gray-400"
+              }
+            >
+              Last verified{" "}
               <time dateTime={content.lastVerified}>
                 {new Date(content.lastVerified).toLocaleDateString("en-US", {
                   year: "numeric",
@@ -228,9 +271,11 @@ export default async function Page({
                   timeZone: "UTC",
                 })}
               </time>
-              .
             </p>
           )}
+          <div id="content" className="prose">
+            <Content />
+          </div>
         </div>
         <div className="hidden w-66 lg:block">
           <TableOfContents contentId="content" />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -99,10 +99,11 @@ export default function RootLayout({
   return (
     <html
       lang="en"
+      suppressHydrationWarning
       className={clsx(
         GeistMono.variable,
         InterVariable.variable,
-        "scroll-pt-16 font-sans antialiased dark:bg-gray-950",
+        "scroll-pt-16 bg-white font-sans antialiased dark:bg-black",
       )}
     >
       <head>
@@ -112,7 +113,7 @@ export default function RootLayout({
         />
         {/* Manifest is handled by metadata.manifest, no need for manual <link> */}
       </head>
-      <body className="dark:bg-gray-950">
+      <body className="bg-white dark:bg-black">
         <WebVitals />
         <div className="isolate">{children}</div>
         <Footer />

--- a/src/components/callout.tsx
+++ b/src/components/callout.tsx
@@ -1,0 +1,110 @@
+import { clsx } from "clsx";
+import type { ReactNode } from "react";
+
+type CalloutVariant = "note" | "tip" | "warning" | "important";
+
+const VARIANT_STYLES: Record<
+  CalloutVariant,
+  { container: string; label: string; icon: ReactNode; defaultTitle: string }
+> = {
+  note: {
+    container:
+      "border-blue-200 bg-blue-50 text-blue-950 dark:border-blue-400/30 dark:bg-blue-400/10 dark:text-blue-100",
+    label: "text-blue-700 dark:text-blue-300",
+    defaultTitle: "Note",
+    icon: (
+      <svg
+        viewBox="0 0 16 16"
+        fill="currentColor"
+        aria-hidden="true"
+        className="h-4 w-4 shrink-0"
+      >
+        <path d="M8 1.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM7.25 4.5a.75.75 0 0 1 1.5 0v.5a.75.75 0 0 1-1.5 0v-.5Zm0 3.5a.75.75 0 0 1 1.5 0v3.5a.75.75 0 0 1-1.5 0V8Z" />
+      </svg>
+    ),
+  },
+  tip: {
+    container:
+      "border-emerald-200 bg-emerald-50 text-emerald-950 dark:border-emerald-400/30 dark:bg-emerald-400/10 dark:text-emerald-100",
+    label: "text-emerald-700 dark:text-emerald-300",
+    defaultTitle: "Tip",
+    icon: (
+      <svg
+        viewBox="0 0 16 16"
+        fill="currentColor"
+        aria-hidden="true"
+        className="h-4 w-4 shrink-0"
+      >
+        <path d="M8 1.5a4.75 4.75 0 0 0-3 8.42v1.33A1.25 1.25 0 0 0 6.25 12.5h3.5a1.25 1.25 0 0 0 1.25-1.25V9.92A4.75 4.75 0 0 0 8 1.5Zm-1.75 12a.75.75 0 0 1 .75-.75h2a.75.75 0 0 1 0 1.5H7a.75.75 0 0 1-.75-.75Z" />
+      </svg>
+    ),
+  },
+  warning: {
+    container:
+      "border-amber-200 bg-amber-50 text-amber-950 dark:border-amber-400/30 dark:bg-amber-400/10 dark:text-amber-100",
+    label: "text-amber-700 dark:text-amber-300",
+    defaultTitle: "Warning",
+    icon: (
+      <svg
+        viewBox="0 0 16 16"
+        fill="currentColor"
+        aria-hidden="true"
+        className="h-4 w-4 shrink-0"
+      >
+        <path d="M7.13 2.32a1 1 0 0 1 1.74 0l5.5 9.5A1 1 0 0 1 13.5 13.3H2.5a1 1 0 0 1-.87-1.5l5.5-9.5ZM7.25 6a.75.75 0 0 1 1.5 0v3a.75.75 0 0 1-1.5 0V6Zm.75 6a.9.9 0 1 0 0-1.8.9.9 0 0 0 0 1.8Z" />
+      </svg>
+    ),
+  },
+  important: {
+    container:
+      "border-rose-200 bg-rose-50 text-rose-950 dark:border-rose-400/30 dark:bg-rose-400/10 dark:text-rose-100",
+    label: "text-rose-700 dark:text-rose-300",
+    defaultTitle: "Important",
+    icon: (
+      <svg
+        viewBox="0 0 16 16"
+        fill="currentColor"
+        aria-hidden="true"
+        className="h-4 w-4 shrink-0"
+      >
+        <path d="M8 1.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13Zm-.75 3a.75.75 0 0 1 1.5 0v4.25a.75.75 0 0 1-1.5 0V4.5Zm.75 7.6a.95.95 0 1 0 0-1.9.95.95 0 0 0 0 1.9Z" />
+      </svg>
+    ),
+  },
+};
+
+export function Callout({
+  variant = "note",
+  title,
+  children,
+}: {
+  variant?: CalloutVariant;
+  title?: string;
+  children: ReactNode;
+}) {
+  const styles = VARIANT_STYLES[variant];
+  const headingText = title ?? styles.defaultTitle;
+
+  return (
+    <aside
+      role="note"
+      className={clsx(
+        "my-6 rounded-lg border px-4 py-3 text-sm not-prose",
+        styles.container,
+      )}
+    >
+      <div
+        className={clsx(
+          "flex items-center gap-x-2 font-semibold uppercase tracking-wide text-xs mb-1",
+          styles.label,
+        )}
+      >
+        {styles.icon}
+        <span>{headingText}</span>
+      </div>
+      <div className="prose prose-sm max-w-none dark:prose-invert [&>:first-child]:mt-0 [&>:last-child]:mb-0">
+        {children}
+      </div>
+    </aside>
+  );
+}

--- a/src/components/centered-layout.tsx
+++ b/src/components/centered-layout.tsx
@@ -12,7 +12,7 @@ export function CenteredPageLayout({
     <div className="pb-30">
       <Navbar />
       {breadcrumbs && (
-        <div className="flex h-10 items-center border-b border-gray-950/10 bg-white px-4 sm:px-6 dark:border-white/10 dark:bg-gray-950">
+        <div className="flex h-10 items-center border-b border-gray-950/10 bg-white px-4 sm:px-6 dark:border-white/10 dark:bg-black">
           <div className="min-w-0 text-sm">{breadcrumbs}</div>
         </div>
       )}

--- a/src/components/doc-placeholder.tsx
+++ b/src/components/doc-placeholder.tsx
@@ -1,0 +1,107 @@
+import { clsx } from "clsx";
+
+type DocPlaceholderKind = "screenshot" | "video" | "diagram";
+
+const KIND_STYLES: Record<
+  DocPlaceholderKind,
+  { label: string; aspectClass: string; icon: React.ReactNode }
+> = {
+  screenshot: {
+    label: "Screenshot",
+    aspectClass: "aspect-video",
+    icon: (
+      <svg
+        viewBox="0 0 16 16"
+        fill="currentColor"
+        aria-hidden="true"
+        className="h-4 w-4"
+      >
+        <path d="M2.5 3.5A1.5 1.5 0 0 1 4 2h2.31a1 1 0 0 1 .85.47l.5.83A1 1 0 0 0 8.5 3.8H12a1.5 1.5 0 0 1 1.5 1.5v6A1.5 1.5 0 0 1 12 12.8H4a1.5 1.5 0 0 1-1.5-1.5V3.5Zm5.5 6.3a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z" />
+      </svg>
+    ),
+  },
+  video: {
+    label: "Video",
+    aspectClass: "aspect-video",
+    icon: (
+      <svg
+        viewBox="0 0 16 16"
+        fill="currentColor"
+        aria-hidden="true"
+        className="h-4 w-4"
+      >
+        <path d="M2 4.5A1.5 1.5 0 0 1 3.5 3h6A1.5 1.5 0 0 1 11 4.5v.94l3-1.7v8.52l-3-1.7v.94A1.5 1.5 0 0 1 9.5 13h-6A1.5 1.5 0 0 1 2 11.5v-7Z" />
+      </svg>
+    ),
+  },
+  diagram: {
+    label: "Diagram",
+    aspectClass: "aspect-[16/9]",
+    icon: (
+      <svg
+        viewBox="0 0 16 16"
+        fill="currentColor"
+        aria-hidden="true"
+        className="h-4 w-4"
+      >
+        <path d="M2.5 2.5a1 1 0 0 1 1-1H6a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H3.5a1 1 0 0 1-1-1v-2Zm6 0a1 1 0 0 1 1-1H12a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H9.5a1 1 0 0 1-1-1v-2ZM2.5 8.5a1 1 0 0 1 1-1H6a1 1 0 0 1 1 1V13a1 1 0 0 1-1 1H3.5a1 1 0 0 1-1-1V8.5Zm6 1.5a1 1 0 0 1 1-1H12a1 1 0 0 1 1 1V13a1 1 0 0 1-1 1H9.5a1 1 0 0 1-1-1v-3Z" />
+      </svg>
+    ),
+  },
+};
+
+/**
+ * Inline placeholder for a screenshot, video, or diagram that hasn't been
+ * captured yet. Renders a styled stand-in with the eventual asset path so
+ * the design team has a clear todo list, and removes the need for broken
+ * <Image> tags or fragile markdown blockquotes.
+ *
+ * When the real asset lands at `src`, swap this for a normal MDX <img> or
+ * <Video> tag — the path you wrote here matches what should ship.
+ */
+export function DocPlaceholder({
+  kind = "screenshot",
+  src,
+  caption,
+  description,
+}: {
+  kind?: DocPlaceholderKind;
+  src: string;
+  caption?: string;
+  description?: string;
+}) {
+  const styles = KIND_STYLES[kind];
+
+  return (
+    <figure className="my-6 not-prose">
+      <div
+        className={clsx(
+          "relative w-full overflow-hidden rounded-xl border border-dashed",
+          "border-gray-300 bg-gray-50 text-gray-500",
+          "dark:border-white/15 dark:bg-white/5 dark:text-gray-400",
+          styles.aspectClass,
+        )}
+        role="img"
+        aria-label={caption ?? `Placeholder for ${kind}: ${src}`}
+      >
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-y-2 p-6 text-center">
+          <div className="flex items-center gap-x-2 text-xs font-semibold uppercase tracking-wider">
+            {styles.icon}
+            <span>{styles.label} placeholder</span>
+          </div>
+          {description && (
+            <p className="max-w-sm text-sm leading-snug">{description}</p>
+          )}
+          <code className="mt-1 break-all rounded bg-gray-950/5 px-2 py-1 font-mono text-xs text-gray-700 dark:bg-white/10 dark:text-gray-200">
+            {src}
+          </code>
+        </div>
+      </div>
+      {caption && (
+        <figcaption className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+          {caption}
+        </figcaption>
+      )}
+    </figure>
+  );
+}

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -6,8 +6,8 @@ import type React from "react";
 
 export function Footer() {
   return (
-    <footer className="border-t border-gray-950/10 bg-white py-8 text-base text-gray-950 dark:border-white/10 dark:bg-gray-950 dark:text-white">
-      <div className="mx-auto flex flex-col items-start gap-6 px-4 sm:flex-row sm:items-center sm:justify-between sm:px-6 xl:ml-[var(--container-2xs)] xl:max-w-none xl:px-12">
+    <footer className="bg-white py-8 text-base text-gray-950 dark:bg-black dark:text-white">
+      <div className="mx-auto flex w-full max-w-[1400px] flex-col items-start gap-6 px-4 sm:flex-row sm:items-center sm:justify-between sm:px-6">
         <div className="flex items-center gap-3">
           <Link href="/" aria-label="Blawby home">
             <Logo height={28} width={110} />

--- a/src/components/logo.tsx
+++ b/src/components/logo.tsx
@@ -18,6 +18,7 @@ export function Logo(props: React.ComponentProps<"svg">) {
         )}
       >
         <path
+          suppressHydrationWarning
           fill="currentColor"
           opacity="1.000000"
           stroke="none"
@@ -574,6 +575,7 @@ M638.068909,919.052368
 z"
         />
         <path
+          suppressHydrationWarning
           fill="currentColor"
           opacity="1.000000"
           stroke="none"
@@ -671,6 +673,7 @@ M1291.263794,832.751953
 z"
         />
         <path
+          suppressHydrationWarning
           fill="currentColor"
           opacity="1.000000"
           stroke="none"

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -71,22 +71,23 @@ export function Navbar() {
     <div
       className={clsx(
         "sticky top-0 z-20 w-full",
-        "bg-white/95 backdrop-blur-sm dark:bg-gray-950/95",
-        "border-b border-gray-950/10 dark:border-white/10",
-        "flex h-14 items-center gap-x-0 px-4 sm:px-6",
+        "bg-white dark:bg-black",
+        "px-4 sm:px-6",
       )}
     >
-      <Link href="/" aria-label="Blawby home" className="flex shrink-0 items-center pr-6">
-        <Logo className="h-7 dark:text-white" />
-      </Link>
+      <div className="mx-auto flex h-14 w-full max-w-[1400px] items-center gap-x-0">
+        <Link href="/" aria-label="Blawby home" className="flex shrink-0 items-center pr-6">
+          <Logo className="h-7 dark:text-white" />
+        </Link>
 
-      {/* Center nav — hidden on mobile */}
-      <PrimaryNav className="hidden h-full lg:flex" />
+        {/* Center nav — hidden on mobile */}
+        <PrimaryNav className="hidden h-full lg:flex" />
 
-      <div className="flex-1" />
+        <div className="flex-1" />
 
-      {/* Right-side actions */}
-      <SiteNavigation />
+        {/* Right-side actions */}
+        <SiteNavigation />
+      </div>
     </div>
   );
 }
@@ -173,7 +174,7 @@ function MobileNavigation({
     <Dialog open={open} onClose={onClose} className="lg:hidden">
       <DialogBackdrop className="fixed inset-0 bg-gray-950/25" />
       <div className="fixed inset-0 flex justify-end pl-11">
-        <DialogPanel className="w-full max-w-xs bg-white px-4 py-5 ring ring-gray-950/10 sm:px-6 dark:bg-gray-950 dark:ring-white/10">
+        <DialogPanel className="w-full max-w-xs bg-white px-4 py-5 ring ring-gray-950/10 sm:px-6 dark:bg-black dark:ring-white/10">
           <div className="flex justify-end">
             <CloseButton as={IconButton} onClick={onClose} aria-label="Close menu">
               <CloseIcon className="stroke-gray-950 dark:stroke-white" />

--- a/src/components/sidebar-layout.tsx
+++ b/src/components/sidebar-layout.tsx
@@ -3,13 +3,15 @@
 import { IconButton } from "@/components/icon-button";
 import { NAV_SECTIONS, PRODUCT_SECTION_IDS } from "@/components/navbar";
 import type { Module } from "@/data/lessons";
+import { ChevronDownIcon } from "@/icons/chevron-down-icon";
 import { SidebarIcon } from "@/icons/sidebar-icon";
+import { formatSectionLabel } from "@/utils/section-label";
 import { Dialog, DialogBackdrop, DialogPanel } from "@headlessui/react";
 import { clsx } from "clsx";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import type React from "react";
-import { createContext, useContext, useState } from "react";
+import { createContext, useContext, useId, useState } from "react";
 
 // ─── Context ──────────────────────────────────────────────────────────────────
 
@@ -29,11 +31,80 @@ export const SidebarContext = createContext<{
 
 import type { ContentItem } from "@/lib/content";
 
+type SidebarLeaf = { kind: "leaf"; href: string; label: string };
+type SidebarGroup = { kind: "group"; label: string; items: SidebarLeaf[] };
+type SidebarItem = SidebarLeaf | SidebarGroup;
+
 type SidebarSection = {
   sectionTitle: string;
-  items: { href: string; label: string }[];
+  items: SidebarItem[];
   id?: string;
 };
+
+/**
+ * Build the sidebar tree for one category: items with no `group` frontmatter
+ * become top-level leaves; items sharing a `group` collapse under a single
+ * group node, sorted by `groupOrder` then `order`.
+ */
+function buildSidebarItemsForCategory(
+  categoryArticles: ContentItem[],
+): SidebarItem[] {
+  const groups = new Map<
+    string,
+    { groupOrder: number; minOrder: number; articles: ContentItem[] }
+  >();
+  const ungrouped: ContentItem[] = [];
+
+  for (const a of categoryArticles) {
+    if (a.group) {
+      const slot = groups.get(a.group);
+      if (slot) {
+        slot.articles.push(a);
+        slot.minOrder = Math.min(slot.minOrder, a.order ?? 999);
+      } else {
+        groups.set(a.group, {
+          groupOrder: a.groupOrder ?? 999,
+          minOrder: a.order ?? 999,
+          articles: [a],
+        });
+      }
+    } else {
+      ungrouped.push(a);
+    }
+  }
+
+  type Entry = { sortKey: number; item: SidebarItem };
+  const entries: Entry[] = [];
+
+  for (const a of ungrouped) {
+    entries.push({
+      sortKey: a.order ?? 999,
+      item: {
+        kind: "leaf",
+        href: `/${a.category.toLowerCase()}/${a.slug}`,
+        label: a.title || "",
+      },
+    });
+  }
+
+  for (const [label, slot] of groups) {
+    const items = slot.articles
+      .slice()
+      .sort((a, b) => (a.order ?? 999) - (b.order ?? 999))
+      .map<SidebarLeaf>((a) => ({
+        kind: "leaf",
+        href: `/${a.category.toLowerCase()}/${a.slug}`,
+        label: a.title || "",
+      }));
+    entries.push({
+      sortKey: slot.groupOrder !== 999 ? slot.groupOrder : slot.minOrder,
+      item: { kind: "group", label, items },
+    });
+  }
+
+  entries.sort((a, b) => a.sortKey - b.sortKey);
+  return entries.map((e) => e.item);
+}
 
 function useSidebarSections(
   modules: Module[],
@@ -48,7 +119,8 @@ function useSidebarSections(
   if (PRODUCT_SECTION_IDS.has(segment.toLowerCase() as any) || segment === "products") {
     return modules.map((mod) => ({
       sectionTitle: mod.title,
-      items: mod.lessons.map((lesson) => ({
+      items: mod.lessons.map<SidebarLeaf>((lesson) => ({
+        kind: "leaf",
         href: `/${lesson.category.toLowerCase()}/${lesson.slug}`,
         label: lesson.title || "",
       })),
@@ -59,38 +131,36 @@ function useSidebarSections(
     const sectionArticles = allContent.filter((a) => a.origin === "solutions");
     const categories = Array.from(new Set(sectionArticles.map((a) => a.category)));
     return categories.map((cat) => ({
-      sectionTitle: cat.replace(/-/g, " "),
-      items: sectionArticles
-        .filter((a) => a.category.toLowerCase() === cat.toLowerCase())
-        .map((a) => ({
-          href: `/${a.category.toLowerCase()}/${a.slug}`,
-          label: a.title || "",
-        })),
+      sectionTitle: cat,
+      items: buildSidebarItemsForCategory(
+        sectionArticles.filter(
+          (a) => a.category.toLowerCase() === cat.toLowerCase(),
+        ),
+      ),
     }));
   }
 
   if (segment === "docs") {
     const sectionDocs = allContent.filter((a) => a.origin === "docs");
     const categories = ["quick-start", "features", "reference"];
-    return categories.map((cat) => {
-      const categoryArticles = sectionDocs.filter(
-        (a) => a.category.toLowerCase() === cat.toLowerCase()
-      );
-      return {
-        sectionTitle: cat.replace(/-/g, " "),
-        items: categoryArticles.map((a) => ({
-          href: `/${a.category.toLowerCase()}/${a.slug}`,
-          label: a.title || "",
-        })),
-      };
-    }).filter(s => s.items.length > 0);
+    return categories
+      .map((cat) => {
+        const categoryArticles = sectionDocs.filter(
+          (a) => a.category.toLowerCase() === cat.toLowerCase(),
+        );
+        return {
+          sectionTitle: cat,
+          items: buildSidebarItemsForCategory(categoryArticles),
+        };
+      })
+      .filter((s) => s.items.length > 0);
   }
 
   if (segment === "pricing") {
     return [
       {
         sectionTitle: "Pricing",
-        items: [{ href: "/pricing", label: "Overview" }],
+        items: [{ kind: "leaf", href: "/pricing", label: "Overview" }],
       },
     ];
   }
@@ -100,8 +170,8 @@ function useSidebarSections(
       {
         sectionTitle: "Legal",
         items: [
-          { href: "/privacy", label: "Privacy Policy" },
-          { href: "/terms", label: "Terms of Service" },
+          { kind: "leaf", href: "/privacy", label: "Privacy Policy" },
+          { kind: "leaf", href: "/terms", label: "Terms of Service" },
         ],
       },
     ];
@@ -113,29 +183,26 @@ function useSidebarSections(
   // Match active article by full route to avoid slug collisions
   // Fallback to category + slug match if origin disambiguation is needed
   const activeArticle = allContent.find(
-    (a) => `/${a.category.toLowerCase()}/${a.slug}` === pathname
+    (a) => `/${a.category.toLowerCase()}/${a.slug}` === pathname,
   ) || allContent.find(
-    (a) => 
-      a.slug === pathname.split("/").pop() && 
-      a.category.toLowerCase() === segment.toLowerCase()
+    (a) =>
+      a.slug === pathname.split("/").pop() &&
+      a.category.toLowerCase() === segment.toLowerCase(),
   );
-  
+
   const activeOrigin = activeArticle?.origin;
 
   const categoryArticles = allContent.filter(
     (a) =>
       a.category.toLowerCase() === segment.toLowerCase() &&
-      a.origin === activeOrigin
+      a.origin === activeOrigin,
   );
   if (!categoryArticles.length) return [];
 
   return [
     {
       sectionTitle: section.label,
-      items: categoryArticles.map((a) => ({
-        href: `/${a.category.toLowerCase()}/${a.slug}`,
-        label: a.title || "",
-      })),
+      items: buildSidebarItemsForCategory(categoryArticles),
     },
   ];
 }
@@ -153,42 +220,218 @@ function SidebarNav({
 }) {
   const pathname = usePathname();
 
+  // Track explicit user toggles for any expandable node (section or sub-group).
+  // Keys are unique paths like "Section" or "Section/Group".
+  const [overrides, setOverrides] = useState<Record<string, boolean>>({});
+
   if (!sections.length) return null;
 
+  const containsActive = (items: SidebarItem[]): boolean =>
+    items.some((item) =>
+      item.kind === "leaf"
+        ? pathname === item.href
+        : containsActive(item.items),
+    );
+
+  const isExpanded = (key: string, items: SidebarItem[]) =>
+    overrides[key] ?? containsActive(items);
+
+  const toggle = (key: string, items: SidebarItem[]) => {
+    setOverrides((prev) => ({
+      ...prev,
+      [key]: !isExpanded(key, items),
+    }));
+  };
+
   return (
-    <div className={clsx(className, "space-y-8")}>
+    <ul className={clsx(className, "relative m-0 list-none p-0")}>
       {sections.map((section) => (
-        <div key={section.sectionTitle} className="mb-10 last:mb-0">
-          <h2 className="text-xs font-semibold tracking-wider text-gray-500 uppercase dark:text-gray-400">
-            {section.sectionTitle}
-          </h2>
-          <ul className="mt-3 flex flex-col gap-0.5 border-l border-gray-950/10 dark:border-white/10">
-            {section.items.map((item) => {
-              const isActive = pathname === item.href;
-              return (
-                <li key={item.href}>
-                  <Link
-                    href={item.href}
-                    onClick={onNavigate}
-                    aria-current={isActive ? "page" : undefined}
-                    className={clsx(
-                      "-ml-px flex border-l py-1.5 pl-4 text-sm/6 transition-colors",
-                      isActive
-                        ? "border-gray-950 font-medium text-gray-950 dark:border-white dark:text-white"
-                        : "border-transparent text-gray-600 hover:border-gray-400 hover:text-gray-950 dark:text-gray-400 dark:hover:border-white/40 dark:hover:text-white",
-                    )}
-                  >
-                    {item.label}
-                  </Link>
-                </li>
-              );
-            })}
-          </ul>
-        </div>
+        <SidebarSectionGroup
+          key={section.sectionTitle}
+          section={section}
+          path={section.sectionTitle}
+          isExpanded={isExpanded(section.sectionTitle, section.items)}
+          onToggle={() => toggle(section.sectionTitle, section.items)}
+          onNavigate={onNavigate}
+          pathname={pathname}
+          isExpandedFn={isExpanded}
+          toggleFn={toggle}
+        />
       ))}
-    </div>
+    </ul>
   );
 }
+
+function SidebarSectionGroup({
+  section,
+  path,
+  isExpanded,
+  onToggle,
+  onNavigate,
+  pathname,
+  isExpandedFn,
+  toggleFn,
+}: {
+  section: SidebarSection;
+  path: string;
+  isExpanded: boolean;
+  onToggle: () => void;
+  onNavigate?: () => void;
+  pathname: string;
+  isExpandedFn: (key: string, items: SidebarItem[]) => boolean;
+  toggleFn: (key: string, items: SidebarItem[]) => void;
+}) {
+  const listId = useId();
+  const sectionLabel = formatSectionLabel(section.sectionTitle);
+
+  return (
+    <li className="relative flex w-full select-none flex-col first:mt-2 last:mb-2">
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={isExpanded}
+        aria-controls={listId}
+        className={clsx(
+          "group flex w-full items-center justify-between gap-x-2 py-[6.5px]",
+          "text-sm font-normal leading-[21px]",
+          "text-gray-700 hover:text-gray-950 dark:text-gray-400 dark:hover:text-white",
+          "transition-colors",
+        )}
+      >
+        <span className="truncate">{sectionLabel}</span>
+        <ChevronDownIcon
+          className={clsx(
+            "h-1.5 w-2 stroke-current transition-transform duration-150",
+            !isExpanded && "-rotate-90",
+          )}
+        />
+      </button>
+
+      <ul
+        id={listId}
+        hidden={!isExpanded}
+        className={clsx(
+          "relative m-0 flex w-full list-none flex-col p-0 pl-3",
+          "before:absolute before:top-2 before:bottom-2 before:left-0 before:w-px",
+          "before:bg-gray-950/10 dark:before:bg-white/10 before:content-['']",
+        )}
+      >
+        {section.items.map((item) =>
+          item.kind === "leaf" ? (
+            <SidebarLeafRow
+              key={item.href}
+              item={item}
+              pathname={pathname}
+              onNavigate={onNavigate}
+            />
+          ) : (
+            <SidebarSubGroup
+              key={item.label}
+              group={item}
+              path={`${path}/${item.label}`}
+              isExpanded={isExpandedFn(`${path}/${item.label}`, item.items)}
+              onToggle={() =>
+                toggleFn(`${path}/${item.label}`, item.items)
+              }
+              onNavigate={onNavigate}
+              pathname={pathname}
+            />
+          ),
+        )}
+      </ul>
+    </li>
+  );
+}
+
+function SidebarSubGroup({
+  group,
+  isExpanded,
+  onToggle,
+  onNavigate,
+  pathname,
+}: {
+  group: SidebarGroup;
+  path: string;
+  isExpanded: boolean;
+  onToggle: () => void;
+  onNavigate?: () => void;
+  pathname: string;
+}) {
+  const listId = useId();
+
+  return (
+    <li className="flex w-full flex-col">
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={isExpanded}
+        aria-controls={listId}
+        className={clsx(
+          "flex w-full items-center justify-between gap-x-2 py-[6.5px]",
+          "text-sm font-normal leading-[21px]",
+          "text-gray-700 hover:text-gray-950 dark:text-gray-400 dark:hover:text-white",
+          "transition-colors",
+        )}
+      >
+        <span className="truncate">{group.label}</span>
+        <ChevronDownIcon
+          className={clsx(
+            "h-1.5 w-2 stroke-current transition-transform duration-150",
+            !isExpanded && "-rotate-90",
+          )}
+        />
+      </button>
+      <ul
+        id={listId}
+        hidden={!isExpanded}
+        className={clsx(
+          "relative m-0 flex w-full list-none flex-col p-0 pl-3",
+          "before:absolute before:top-2 before:bottom-2 before:left-0 before:w-px",
+          "before:bg-gray-950/10 dark:before:bg-white/10 before:content-['']",
+        )}
+      >
+        {group.items.map((item) => (
+          <SidebarLeafRow
+            key={item.href}
+            item={item}
+            pathname={pathname}
+            onNavigate={onNavigate}
+          />
+        ))}
+      </ul>
+    </li>
+  );
+}
+
+function SidebarLeafRow({
+  item,
+  pathname,
+  onNavigate,
+}: {
+  item: SidebarLeaf;
+  pathname: string;
+  onNavigate?: () => void;
+}) {
+  const isActive = pathname === item.href;
+  return (
+    <li className="flex w-full">
+      <Link
+        href={item.href}
+        onClick={onNavigate}
+        aria-current={isActive ? "page" : undefined}
+        className={clsx(
+          "flex w-full py-[6.5px] text-sm font-normal leading-[21px] transition-colors",
+          isActive
+            ? "text-gray-950 dark:text-white"
+            : "text-gray-700 hover:text-gray-950 dark:text-gray-400 dark:hover:text-white",
+        )}
+      >
+        {item.label}
+      </Link>
+    </li>
+  );
+}
+
 
 // ─── Mobile sidebar sheet ─────────────────────────────────────────────────────
 
@@ -204,7 +447,7 @@ function MobileSidebar({
   return (
     <Dialog open={open} onClose={onClose} className="xl:hidden">
       <DialogBackdrop className="fixed inset-0 bg-gray-950/25" />
-      <DialogPanel className="fixed inset-y-0 left-0 w-72 overflow-y-auto bg-white px-4 py-6 pt-20 ring ring-gray-950/10 sm:px-6 dark:bg-gray-950 dark:ring-white/10">
+      <DialogPanel className="fixed inset-y-0 left-0 w-72 overflow-y-auto bg-white px-4 py-6 pt-20 ring ring-gray-950/10 sm:px-6 dark:bg-black dark:ring-white/10">
         <SidebarNav sections={sections} onNavigate={onClose} />
       </DialogPanel>
     </Dialog>
@@ -238,32 +481,26 @@ export function SidebarLayout({
     >
       <div
         data-sidebar-collapsed={isSidebarOpen ? undefined : ""}
-        className="group"
+        className="group mx-auto flex w-full max-w-[1400px]"
       >
-        {/* Desktop sidebar — only when there are sections to show */}
+        {/* Desktop sidebar — sticky in normal flow, lives inside the centered
+            max-width container so on wide viewports it shifts toward center
+            with the content (Vercel pattern). */}
         {hasSidebar && (
           <aside
             className={clsx(
-              // Sits below the single-row navbar (h-14 = 56px)
-              "fixed inset-y-0 top-14 left-0 w-64 overflow-y-auto",
-              "border-r border-gray-950/10 dark:border-white/10",
-              "group-data-[sidebar-collapsed]:hidden max-xl:hidden",
+              "sticky top-14 hidden h-[calc(100vh-3.5rem)] w-[300px] shrink-0 overflow-y-auto xl:block",
+              "group-data-[sidebar-collapsed]:hidden",
             )}
           >
-            <nav aria-label="Sidebar navigation" className="px-5 py-6">
+            <nav aria-label="Sidebar navigation" className="px-8 py-3">
               <SidebarNav sections={sections} />
             </nav>
           </aside>
         )}
 
-        {/* Page content — shift right when desktop sidebar is visible */}
-        <div
-          className={clsx(
-            hasSidebar && "xl:ml-64 xl:group-data-[sidebar-collapsed]:ml-0",
-          )}
-        >
-          {children}
-        </div>
+        {/* Page content fills the rest of the centered container. */}
+        <div className="min-w-0 flex-1">{children}</div>
       </div>
 
       {/* Mobile sidebar */}
@@ -298,11 +535,11 @@ export function SidebarLayoutContent({
   const isHome = pathname === "/";
 
   return (
-    <>
-
-      {/* Sub-header: breadcrumbs + sidebar toggles. Below sticky nav, inside content flow. */}
-      {!isHome && (
-        <div className="flex h-10 items-center gap-x-3 border-b border-gray-950/10 bg-white px-4 sm:px-6 dark:border-white/10 dark:bg-gray-950">
+    <main className="px-4 sm:px-6">
+      {/* Inline breadcrumb row — Vercel pattern: sidebar toggle + crumbs in the
+          article gutter, scrolling with content. No background, no border. */}
+      {!isHome && (breadcrumbs || hasSidebar(pathname)) && (
+        <div className="mx-auto flex max-w-2xl items-center gap-x-3 pt-6 sm:pt-8 lg:max-w-5xl">
           {/* Mobile sidebar toggle */}
           <IconButton
             onClick={() => setIsMobileDialogOpen(!isMobileDialogOpen)}
@@ -324,11 +561,21 @@ export function SidebarLayoutContent({
               <SidebarIcon className="shrink-0 stroke-gray-950 dark:stroke-white" />
             </IconButton>
           )}
-          {breadcrumbs && <div className="min-w-0 text-sm">{breadcrumbs}</div>}
+          {breadcrumbs && (
+            <div className="min-w-0 text-sm text-gray-700 dark:text-gray-400">
+              {breadcrumbs}
+            </div>
+          )}
         </div>
       )}
 
-      <main className="px-4 sm:px-6">{children}</main>
-    </>
+      {children}
+    </main>
   );
+}
+
+function hasSidebar(pathname: string): boolean {
+  // Inline-breadcrumb row also surfaces the sidebar toggle, so render it on
+  // any non-home route. Home has no sidebar so we hide the row entirely there.
+  return pathname !== "/";
 }

--- a/src/data/docs/features/engagements-overview.mdx
+++ b/src/data/docs/features/engagements-overview.mdx
@@ -5,6 +5,8 @@ image: "https://imagedelivery.net/Frxyb2_d_vGyiaXhS5xqCg/527f8451-2748-4f04-ea0f
 author: "Paul Chris Luke"
 authorImage: "/images/logo.png"
 category: "features"
+group: "Engagements"
+groupOrder: 20
 contentType: "guide"
 order: 35
 createdAt: "05/07/2026"
@@ -45,7 +47,7 @@ This page explains the four sections of an engagement, the lifecycle from draft 
 
 <DocPlaceholder
   kind="video"
-  src="/docs/engagements/walkthrough.mp4"
+  src="/media/docs/engagements/walkthrough.mp4"
   description="60-second walkthrough of creating an engagement from a matter — Blawby pre-fills the four sections, attorney edits, sends, client signs."
 />
 
@@ -74,7 +76,7 @@ What the firm is and isn't doing for this client.
 
 <DocPlaceholder
   kind="screenshot"
-  src="/docs/engagements/representation-section.png"
+  src="/media/docs/engagements/representation-section.png"
   description="Representation section with included and excluded services rendered side-by-side."
 />
 
@@ -144,7 +146,7 @@ The client opens a clean, branded review page — no Blawby login required.
 
 <DocPlaceholder
   kind="screenshot"
-  src="/docs/engagements/client-review-page.png"
+  src="/media/docs/engagements/client-review-page.png"
   description="ClientEngagementReviewPage with sections collapsed and the sign button at the bottom."
 />
 

--- a/src/data/docs/features/engagements-overview.mdx
+++ b/src/data/docs/features/engagements-overview.mdx
@@ -1,0 +1,189 @@
+---
+title: "Engagements Overview: Scope, Fees, and Risk Review"
+desc: "How Blawby engagement letters work: representation scope, fees, conflict and jurisdiction review, and client signing — from draft to accepted."
+image: "https://imagedelivery.net/Frxyb2_d_vGyiaXhS5xqCg/527f8451-2748-4f04-ea0f-805a4214cd00/public"
+author: "Paul Chris Luke"
+authorImage: "/images/logo.png"
+category: "features"
+contentType: "guide"
+order: 35
+createdAt: "05/07/2026"
+updatedAt: "05/07/2026"
+lastVerified: "05/07/2026"
+tags:
+  - Engagements
+  - Engagement-Letter
+  - Representation-Scope
+  - Conflict-Check
+  - Client-Acceptance
+keywords:
+  - Blawby engagement letter
+  - Legal engagement letter software
+  - Conflict and jurisdiction check
+  - Client engagement acceptance
+  - Representation scope
+difficulty: "intermediate"
+prerequisites: ["review-and-triage-intake"]
+timeToComplete: "20 minutes"
+nextSteps: ["manage-matters"]
+schemaType: "HowTo"
+faq:
+  - question: "What is an engagement in Blawby?"
+    answer: "It's the formal agreement between your firm and a prospective client that confirms scope, fees, and risk review before work begins. Acceptance turns a qualified intake into an active matter."
+  - question: "Who creates the engagement?"
+    answer: "An attorney, after reviewing an accepted intake. Blawby pre-fills representation, fees, and risk-review sections from intake and matter context, which the attorney edits and finalizes."
+  - question: "What happens after the client accepts?"
+    answer: "The engagement is recorded as Accepted, and the matter moves to active. The client can be billed for any retainer or initial fee defined on the engagement, and time logged on the matter starts to roll into invoices."
+noindex: false
+---
+
+# Engagements Overview
+
+The engagement letter is the moment a qualified intake becomes a real client relationship. Blawby treats it as a structured object — not a free-text PDF — so the scope, fees, and risk review can be edited, saved, and re-sent without retyping the whole letter.
+
+This page explains the four sections of an engagement, the lifecycle from draft to accepted, and what the client experiences when you send it.
+
+<DocPlaceholder
+  kind="video"
+  src="/docs/engagements/walkthrough.mp4"
+  description="60-second walkthrough of creating an engagement from a matter — Blawby pre-fills the four sections, attorney edits, sends, client signs."
+/>
+
+## Lifecycle
+
+```
+Draft  →  Sent  →  Accepted  |  Declined
+```
+
+- **Draft** — internal. Edit freely.
+- **Sent** — the client received a notification with a link to review and sign.
+- **Accepted** — the client has signed. The matter advances to active and any retainer/initial fee can be billed.
+- **Declined** — the client passed. The matter doesn't advance; you can revise and resend or close it out.
+
+## The four sections of an engagement
+
+### 1. Representation
+
+What the firm is and isn't doing for this client.
+
+- **Scope summary** — a short, plain-language statement of the work.
+- **Included services** — bullet list of what's covered.
+- **Excluded services** — what's *not* covered. This is the boundary that prevents scope creep down the line.
+- **Client identity notes** — for joint engagements, who the firm represents and any co-clients or non-clients (e.g., spouse not represented in an estate plan).
+- **Jurisdiction notes** — where the work will be performed.
+
+<DocPlaceholder
+  kind="screenshot"
+  src="/docs/engagements/representation-section.png"
+  description="Representation section with included and excluded services rendered side-by-side."
+/>
+
+### 2. Fees
+
+How billing will work for the engagement.
+
+- **Billing type** — flat fee, hourly, retainer, or contingency.
+- **Fixed fee** — for flat-fee engagements.
+- **Hourly rates** — separate rates for attorney and admin work.
+- **Contingency percentage** — for contingency engagements, plus any costs deducted off the top.
+- **Retainer amount** — initial deposit for retainer engagements.
+- **Payment frequency** — when invoices will be sent (e.g., monthly, on milestones).
+- **Fee notes** — anything that doesn't fit a checkbox: minimum draws, premium-time terms, expense pass-throughs.
+
+The billing type set here flows automatically into the matter once the engagement is accepted.
+
+[Read more about the four billing types](/business-strategy/future-proof-revenue)
+
+### 3. Risk review
+
+The engagement is also where conflict and jurisdiction status are recorded — before you commit.
+
+- **Conflict status** — clear, conflict identified, or pending review.
+- **Jurisdiction status** — confirmed admitted in the jurisdiction, pending pro hac vice, or referral needed.
+- **Risk notes** — anything elevated: prior representation of an opposing party, statute-of-limitations exposure, regulatory complexity.
+- **Open questions** — what still needs to be answered before the firm can commit.
+
+If conflict or jurisdiction status isn't clear, hold the engagement in Draft until it is.
+
+### 4. Acknowledgments
+
+The legal language the client agrees to when they sign.
+
+- No-guarantee disclaimers.
+- Fee dispute resolution.
+- Termination terms.
+- Anything else your jurisdiction's rules of professional conduct require.
+
+These are configurable per practice — set them once in your practice settings and they apply to every engagement.
+
+## Client summary
+
+Above the four sections, every engagement carries a short client-facing summary: matter description, location, the client's stated goal, and the names of the client(s), co-clients, and non-clients. This is what the client reads first when they open the engagement to review it.
+
+This summary is auto-generated from the intake and matter context, and the attorney can edit it before sending.
+
+## Sending the engagement
+
+1. **Open the matter** the engagement is for.
+2. **Create engagement** — Blawby pre-fills the four sections from the intake answers, your firm's defaults, and the matter context.
+3. **Edit and review.** Pay particular attention to:
+   - Scope — does "included" match what you actually quoted?
+   - Fees — are the rates and billing type right for this matter?
+   - Risk review — are conflict and jurisdiction statuses clear?
+4. **Send.** The client gets an email and (if subscribed) a push notification linking to the review page.
+
+## What the client experiences
+
+The client opens a clean, branded review page — no Blawby login required.
+
+- They see the client summary at the top.
+- They scroll through representation, fees, risk acknowledgments, and the legal language.
+- They can ask questions in the chat thread (their messages route back to the matter).
+- They sign with a typed signature; the signature, IP, and timestamp are recorded.
+- On acceptance, they're redirected to pay any retainer or initial fee defined in the Fees section.
+
+<DocPlaceholder
+  kind="screenshot"
+  src="/docs/engagements/client-review-page.png"
+  description="ClientEngagementReviewPage with sections collapsed and the sign button at the bottom."
+/>
+
+## After acceptance
+
+Once an engagement is accepted:
+
+- The matter status moves to active.
+- The billing type from the Fees section is applied to the matter automatically.
+- Any retainer or initial fee is invoiced.
+- Time logged on the matter from this point will roll into future invoices.
+- The accepted engagement is preserved as a versioned record. Re-engagements (e.g., scope expansion) create a new engagement; the original isn't overwritten.
+
+## Versioning and amendments
+
+Scope changes happen. The model:
+
+- An accepted engagement is **immutable**.
+- Scope expansions create a **new engagement** referencing the prior one.
+- The client signs the new one the same way.
+
+This keeps your audit trail clean — you can always look back and see exactly what was agreed to, when.
+
+## Common scenarios
+
+**Joint estate plan with two spouses.**
+Use co-clients. Representation notes call out which spouse is the primary and any conflict caveats.
+
+**Contingency case with a flat-fee carve-out (e.g., an evaluation).**
+Two engagements: one for the flat-fee evaluation, then if you proceed, a contingency engagement for representation.
+
+**Pro hac vice still pending.**
+Set jurisdiction status to "pending" and hold in Draft. Send only after admission.
+
+**Conflict identified mid-review.**
+Mark conflict status accordingly, document the resolution (waiver, withdrawal, screening), and update risk notes before sending.
+
+## Next: manage the active matter
+
+Once the engagement is accepted, all the billable work, files, and communication live on the matter.
+
+[Continue to Matters Overview](/features/matters-overview)

--- a/src/data/docs/features/failed-payment-and-chargeback-sop.mdx
+++ b/src/data/docs/features/failed-payment-and-chargeback-sop.mdx
@@ -5,6 +5,8 @@ image: "https://imagedelivery.net/Frxyb2_d_vGyiaXhS5xqCg/527f8451-2748-4f04-ea0f
 author: "Paul Chris Luke"
 authorImage: "/images/logo.png"
 category: "features"
+group: "Trust & Compliance"
+groupOrder: 40
 contentType: "guide"
 order: 30
 createdAt: "04/30/2026"

--- a/src/data/docs/features/intake-templates.mdx
+++ b/src/data/docs/features/intake-templates.mdx
@@ -5,6 +5,8 @@ image: "https://imagedelivery.net/Frxyb2_d_vGyiaXhS5xqCg/527f8451-2748-4f04-ea0f
 author: "Paul Chris Luke"
 authorImage: "/images/logo.png"
 category: "features"
+group: "Intake"
+groupOrder: 10
 contentType: "guide"
 order: 15
 createdAt: "05/07/2026"
@@ -44,7 +46,7 @@ This page covers the template model: the four kinds of inputs you configure, the
 
 <DocPlaceholder
   kind="video"
-  src="/docs/intake/template-walkthrough.mp4"
+  src="/media/docs/intake/template-walkthrough.mp4"
   description="30-second walkthrough of IntakeTemplatesPage — creating a template, adding a required field, adding an enrichment field, toggling consultation fee."
 />
 
@@ -71,7 +73,7 @@ Every field has the same shape:
 
 <DocPlaceholder
   kind="screenshot"
-  src="/docs/intake/field-editor-annotated.png"
+  src="/media/docs/intake/field-editor-annotated.png"
   description="Annotated IntakeTemplatesPage field editor with ① required toggle, ② enrichment toggle, ③ conditional dependsOn selector."
 />
 
@@ -135,7 +137,7 @@ What you experience:
 
 <DocPlaceholder
   kind="screenshot"
-  src="/docs/intake/payment-card-in-chat.png"
+  src="/media/docs/intake/payment-card-in-chat.png"
   description="Stripe Elements payment card in the chat thread, between contact collection and submission confirmation."
 />
 

--- a/src/data/docs/features/intake-templates.mdx
+++ b/src/data/docs/features/intake-templates.mdx
@@ -1,0 +1,170 @@
+---
+title: "Intake Templates: Fields, Conditions, and Fees"
+desc: "Configure required vs. enrichment fields, conditional logic, and consultation fees in Blawby intake templates so submissions land ready to triage."
+image: "https://imagedelivery.net/Frxyb2_d_vGyiaXhS5xqCg/527f8451-2748-4f04-ea0f-805a4214cd00/public"
+author: "Paul Chris Luke"
+authorImage: "/images/logo.png"
+category: "features"
+contentType: "guide"
+order: 15
+createdAt: "05/07/2026"
+updatedAt: "05/07/2026"
+lastVerified: "05/07/2026"
+tags:
+  - Client-Intake
+  - Intake-Templates
+  - Configuration
+  - Conditional-Logic
+keywords:
+  - Blawby intake template
+  - Required intake fields
+  - Enrichment fields legal intake
+  - Conditional intake fields
+  - Consultation fee intake
+difficulty: "intermediate"
+prerequisites: ["create-practice-account"]
+timeToComplete: "20 minutes"
+nextSteps: ["review-and-triage-intake"]
+schemaType: "HowTo"
+faq:
+  - question: "What is the difference between a required field and an enrichment field?"
+    answer: "Required fields gate submission — the AI keeps asking until they're filled. Enrichment fields are offered after submission as 'strengthen your case' and are optional, designed to upgrade case quality without blocking the lead."
+  - question: "Can intake fields depend on previous answers?"
+    answer: "Yes. Each field can declare a dependsOn rule, so the AI only asks the question when a parent answer matches a specific value."
+  - question: "How does the consultation fee work?"
+    answer: "When you set a consultation fee on a template, submission is gated on a successful Stripe payment. The intake reaches your queue only after the client pays."
+noindex: false
+---
+
+# Intake Templates
+
+An intake template is the script your AI follows when a potential client opens your widget. It defines what gets collected, what's required vs. optional, what gets gated on payment, and how the conversation branches.
+
+This page covers the template model: the four kinds of inputs you configure, the conditional logic that keeps conversations short, and the consultation-fee flow.
+
+<DocPlaceholder
+  kind="video"
+  src="/docs/intake/template-walkthrough.mp4"
+  description="30-second walkthrough of IntakeTemplatesPage — creating a template, adding a required field, adding an enrichment field, toggling consultation fee."
+/>
+
+## The four parts of a template
+
+| Part | Purpose | Behavior |
+|---|---|---|
+| **Required fields** | What your team needs to triage | AI keeps asking until filled. Submission is blocked otherwise. |
+| **Enrichment fields** | "Strengthen your case" extras | Offered *after* submission. Optional, used to qualify stronger leads. |
+| **Consultation fee** *(optional)* | Charge before submission | Stripe payment gates the submission. No fee, no queue entry. |
+| **Legal disclaimer** | Pre-collection notice | Shown once, before contact info. Configurable per template. |
+
+The mental model: **required = "must have to triage," enrichment = "nice to have for the consult."** Don't over-stuff required fields — every additional required question is a chance for the lead to drop off.
+
+## What goes in a field
+
+Every field has the same shape:
+
+- `key` — internal identifier you'll see in the queue (e.g. `case_summary`)
+- `label` — what the AI says to the client (e.g. "What happened?")
+- `type` — `text`, `select`, `date`, `boolean`, or `number`
+- `required` *(optional)* — gate submission on this field
+- `dependsOn` *(optional)* — only ask this if a parent answer matches
+
+<DocPlaceholder
+  kind="screenshot"
+  src="/docs/intake/field-editor-annotated.png"
+  description="Annotated IntakeTemplatesPage field editor with ① required toggle, ② enrichment toggle, ③ conditional dependsOn selector."
+/>
+
+## Standard fields you'll usually want required
+
+The shorter the required list, the higher the completion rate. The fields most firms need to triage at all:
+
+- **Contact** — name, email, phone (the AI collects these in one step).
+- **Matter type** — single-select against your practice areas.
+- **Case summary** — short free-text describing what happened.
+- **Jurisdiction / location** — where the matter sits (used for filing-deadline calculations and conflict checks).
+- **Urgency** — low / medium / high.
+
+## Enrichment fields: the upsell to better leads
+
+Once a client submits, the widget can offer "strengthen your case" — an optional enrichment phase. This is where you ask the questions that aren't worth losing the lead over:
+
+- Opposing party
+- Documents the client has on hand
+- Court dates or deadlines
+- Desired outcome
+- Prior counsel involvement
+
+If the client skips, you still have a triageable submission. If they engage, your attorney walks into the consult with a much fuller picture.
+
+## Conditional logic with `dependsOn`
+
+Most intakes have questions that only apply in some cases. Use `dependsOn` to hide them when they don't:
+
+```yaml
+- key: court_date
+  label: "When is your next court date?"
+  type: date
+  dependsOn:
+    field: has_open_case
+    value: true
+```
+
+The AI only asks `court_date` when the client previously answered `true` to `has_open_case`. This keeps conversations short and stops the widget from feeling like a form.
+
+## Consultation fees
+
+If your practice charges for the first consultation, set the fee on the template:
+
+1. **Open the template.** Toggle **Require payment**.
+2. **Set the amount** in dollars.
+3. **Save.** The widget will now collect the fee via Stripe before submitting.
+
+What the client experiences:
+
+1. Conversational intake collects the required fields.
+2. A Stripe payment card appears in the chat thread.
+3. On successful payment, the intake submits to your queue.
+4. (Optional) The enrichment phase begins — they're already paid, you're already in their corner.
+
+What you experience:
+
+- The intake reaches your queue **only after** payment clears.
+- The payment is recorded against the future matter.
+- Refunds are managed in the dashboard if the matter is declined.
+
+<DocPlaceholder
+  kind="screenshot"
+  src="/docs/intake/payment-card-in-chat.png"
+  description="Stripe Elements payment card in the chat thread, between contact collection and submission confirmation."
+/>
+
+## Multi-language and RTL
+
+Templates render in 18 languages. The widget detects browser language and switches automatically. Arabic intakes render right-to-left end-to-end. You author the template once; the AI translates question phrasing for the active locale.
+
+[Read more about multilingual intake](/ai-chat/modern-intake-flow)
+
+## Testing a template before you go live
+
+1. **Open your widget URL** from the dashboard in a private browser window.
+2. **Run a happy-path submission** with realistic answers.
+3. **Confirm the submission lands** in your intake queue, with all the fields you expected.
+4. **Confirm the right team member** gets the notification (in-app, email, or push).
+5. **Run a payment-required path** if you've enabled fees — use a Stripe test card.
+
+Document any field labels that confuse you during the test — those are the ones real clients will misread first.
+
+## Common mistakes
+
+- **Too many required fields.** Anything you can ask in the consult shouldn't gate submission.
+- **Required questions that need legal nuance.** "Do you think this is negligence?" is an enrichment question, not a required one — clients won't know the answer.
+- **No `dependsOn` rules.** The widget feels like a form when it asks 20 questions in a row regardless of context.
+- **Enrichment fields with leading questions.** If your enrichment phase reads like a sales script, the lead bails.
+- **Forgotten consultation fee on free-consult firms.** Conversely: if you don't charge for first consults, leave the fee off — gating on a $0 payment is a waste.
+
+## Next: review the queue
+
+When a submission lands, your team triages it from the intake queue.
+
+[Continue to Review and Triage Client Intakes](/features/review-and-triage-intake)

--- a/src/data/docs/features/join-client-conversation.mdx
+++ b/src/data/docs/features/join-client-conversation.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Join a Client Conversation"
-desc: "After accepting an intake, here's how to join the live chat conversation with your potential client in Blawby."
+title: "Join a Client Conversation — Chat, Files, AI Assist"
+desc: "After accepting an intake, work the live conversation thread in Blawby — text, file uploads, quick-reply buttons, payment cards, and paralegal AI assistance."
 image: "/og-images/default.png"
 alt: "Join a client conversation in Blawby"
 author: "Paul Chris Luke"
@@ -9,76 +9,136 @@ category: "features"
 contentType: "guide"
 order: 30
 createdAt: "04/30/2026"
-updatedAt: "04/30/2026"
+updatedAt: "05/07/2026"
+lastVerified: "05/07/2026"
 tags:
   - Conversation
   - Chat
-  - Client-Communication
+  - File-Sharing
+  - Paralegal-AI
 keywords:
-  - Join client chat
-  - Blawby conversation
-  - Client messaging
-  - Lawyer client chat
-summary: "Learn how to join and manage client conversations in Blawby after intake acceptance."
+  - Join client chat Blawby
+  - Live chat law firm
+  - Lawyer client conversation
+  - Paralegal AI chat
+summary: "Work the live conversation thread after intake acceptance — messages, files, quick replies, payment cards, and AI document analysis."
 faq:
-  - Question: "When can I join the conversation?"
-    answer: "After the intake is accepted, the conversation becomes available to your team in Blawby chat."
-  - Question: "Can I include a paralegal in the conversation?"
-    answer: "Yes. Add the appropriate team members as assignees so the right people can support communication."
-  - Question: "Can clients send files in chat?"
-    answer: "Clients can share supporting information and files through the matter workflow where file sharing is enabled."
+  - question: "When does the conversation become available?"
+    answer: "As soon as you accept the intake. The thread is created automatically with the intake context and available to your assigned team."
+  - question: "Can I share files with the client?"
+    answer: "Yes, in both directions. The widget supports uploads up to 25 MB per file (images, video, audio, PDF, Word). Files appear as attachment cards in the thread."
+  - question: "What's the AI doing during the conversation?"
+    answer: "The conversation runs in CONVERSATION mode by default — it's a two-way chat where the AI assists rather than drives. The AI can also stream paralegal-style document analysis when the client uploads files."
 schemaType: "HowTo"
 noindex: false
 ---
 
 # Join a Client Conversation
 
-After intake acceptance, speed and clarity matter. Reaching out quickly in chat helps the client feel supported and helps your team move the matter forward without email back-and-forth.
+After you accept an intake, the conversation thread opens for your team. This is where the actual lawyer/client back-and-forth happens — confirmations, file requests, scheduling, payment requests, and the prep work that leads to an engagement.
 
-## What Makes the Conversation Available
+This page covers what's in the chat surface, what the AI is and isn't doing, and the rhythm that converts an accepted intake into a signed engagement.
 
-A conversation is available for your team once the intake is accepted in Blawby.
+<DocPlaceholder
+  kind="video"
+  src="/docs/chat/conversation-walkthrough.mp4"
+  description="60-second walkthrough of an active conversation — sending a message, attaching a file, the AI surfacing a quick-reply suggestion, and paralegal analysis streaming in."
+/>
 
-## Where to Find Conversations
+## How the chat works
 
-Open your Blawby dashboard and go to your conversation/chat area. Locate the accepted intake conversation and open the thread.
+Blawby chat runs in different **modes** depending on context. After intake acceptance, the conversation is in **CONVERSATION** mode — a two-way thread where you (the firm) drive and the AI assists. Earlier modes:
 
-## Send Your First Message
+| Mode | When |
+|---|---|
+| `REQUEST_CONSULTATION` | The original intake conversation — AI walks the client through your template. |
+| `ASK_QUESTION` | A lightweight question the client asked outside intake. |
+| `PRACTICE_ONBOARDING` | The setup conversation when you first signed up. |
+| `CONVERSATION` | What you're working in now — post-acceptance, attorney-led, AI-assisted. |
 
-Your first message should do three things:
+You don't pick the mode manually; the platform routes the first message. After acceptance, conversation mode is the default.
 
-1. Confirm you reviewed their intake
-2. Set expectations for next steps
-3. Tell them what you need next (if anything)
+## What's in the message stream
 
-A simple opening works well:
+A conversation thread renders several message types inline:
 
-"Thanks for submitting your intake. We reviewed your details and can move forward. Next, we'll walk you through engagement and payment so we can begin work."
+- **Text** — your messages and the client's, with markdown rendering, code blocks, and inline formatting.
+- **Files** — attachment cards. 25 MB per file (images, video, audio, PDF, Word). Camera capture works on mobile.
+- **Quick-reply buttons** — the AI suggests next-step actions extracted from your message ("Schedule consult," "Request retainer," "Open payment link").
+- **Payment cards** — when you send a payment request, a Stripe Elements card renders inline. The client pays without leaving the thread.
+- **Engagement proposal** — once you send an engagement, the proposal renders for the client to review and sign in-thread.
+- **Paralegal analysis** — when the client uploads a document, the AI streams "📄 Analyzing…" status, then surfaces extracted facts (parties, dates, amounts, deadlines, risks).
 
-## What the Client Sees
+## Send your first message after acceptance
 
-On the client side, they see the same conversation thread and can respond in real time. This keeps communication in one place instead of splitting updates across phone, email, and text.
+Three things to do in the first message:
 
-## Requesting Files and Additional Information
+1. **Confirm you reviewed the intake.** Reduces client anxiety.
+2. **Set expectations for next steps.** "Within 24 hours we'll send a short engagement letter" beats "we'll be in touch."
+3. **Tell them what you need next**, if anything (one ID document, a contract scan, a court date confirmation).
 
-When needed, use the conversation to request supporting details and direct the client to upload documents through the Blawby matter workflow once available.
+A simple opener that works:
 
-Keep requests specific:
+> Thanks for the details. I've reviewed your intake and we can move forward. Next up: I'll send a short engagement letter outlining scope and fees. Please reply here if you have a contract or notice you'd like me to review before that goes out.
 
-- What you need
-- Why you need it
-- By when it helps to receive it
+Keep it tight. The longer your first message, the longer the gap before they respond.
 
-## Involving Team Members
+## Requesting files
 
-Add the right internal assignees so communication does not depend on one person. Typical model:
+Two paths:
 
-- Attorney owns legal direction
-- Paralegal supports follow-up and document collection
-- Billing/admin supports payment steps
+- **Ask in chat.** "Could you upload the police report?" — the client sees a clear inline request and uploads in the same thread.
+- **Standard intake enrichment fields.** If documents are something you ask for on most matters, add them as enrichment fields on your intake template so they're collected automatically.
 
-## Next Step
+Always say **what** you need, **why**, and **by when**:
 
-Once the client conversation is active, send engagement terms and move to payment.
+> I need the contract you signed in March. It tells me which clauses apply to your termination notice. If you can upload it by Friday, that lets me have the engagement letter to you by Monday.
 
-[Send an Engagement and Collect Payment](/features/send-engagement-and-collect-payment)
+## When the AI does paralegal analysis
+
+When the client uploads a file, the paralegal AI may automatically stream analysis in chat — extracted parties, dates, deadlines, dollar amounts, and identified risks. The status updates ("📄 Analyzing… 📅 Found 2 deadlines… ⚠️ Flagged 1 risk…") show up live as the analysis runs.
+
+This is meant for **first-pass review** — a fast read on what's in the document. It's not a substitute for your own review, but it puts the right starting questions in front of you faster than reading from page one.
+
+<DocPlaceholder
+  kind="screenshot"
+  src="/docs/chat/paralegal-analysis-stream.png"
+  description="Paralegal AI streaming analysis in the conversation thread — file uploaded, status messages, extracted facts inline."
+/>
+
+## Involving team members
+
+Add team assignees on the matter (see **Settings tab** in the matter detail) so communication doesn't depend on one person:
+
+- **Attorney** — legal direction, engagement decisions, settlement-level calls.
+- **Paralegal** — document collection, scheduling, follow-ups.
+- **Billing/admin** — invoices, payment requests, retainer top-ups.
+
+All assignees see the conversation; their actions log to the matter's Activity tab.
+
+## What the client sees
+
+The client sees the same thread you do, minus internal-only items:
+
+- Internal notes on the matter (Notes tab) are hidden from them.
+- Internal-only Activity log entries (e.g., "team member added") are hidden.
+- Quick-reply buttons render slightly differently — more prominent on the client side.
+
+If they reply on a different device, the conversation continues seamlessly. Better Auth sessions follow them across devices.
+
+## Practical patterns
+
+**Schedule the consult in chat.**
+A two-message pattern works: "Here are three slots: Tue 2pm, Wed 10am, Thu 4pm. Reply with what works." Replace with a calendar link if you have one.
+
+**Send a payment request the same day you accept.**
+Inline payment cards convert faster than emailed invoices. For consultation fees, the card lands directly in the thread.
+
+**Trigger the engagement letter as soon as scope is clear.**
+Don't make the client chase the engagement. Send it the same day or the next morning while interest is high.
+
+## Next: send the engagement letter and collect payment
+
+Once you have what you need, send the engagement and move the matter to active.
+
+[Continue to Send an Engagement and Collect Payment](/features/send-engagement-and-collect-payment)

--- a/src/data/docs/features/join-client-conversation.mdx
+++ b/src/data/docs/features/join-client-conversation.mdx
@@ -6,6 +6,8 @@ alt: "Join a client conversation in Blawby"
 author: "Paul Chris Luke"
 authorImage: "/images/logo.png"
 category: "features"
+group: "Intake"
+groupOrder: 10
 contentType: "guide"
 order: 30
 createdAt: "04/30/2026"
@@ -41,7 +43,7 @@ This page covers what's in the chat surface, what the AI is and isn't doing, and
 
 <DocPlaceholder
   kind="video"
-  src="/docs/chat/conversation-walkthrough.mp4"
+  src="/media/docs/chat/conversation-walkthrough.mp4"
   description="60-second walkthrough of an active conversation — sending a message, attaching a file, the AI surfacing a quick-reply suggestion, and paralegal analysis streaming in."
 />
 
@@ -102,7 +104,7 @@ This is meant for **first-pass review** — a fast read on what's in the documen
 
 <DocPlaceholder
   kind="screenshot"
-  src="/docs/chat/paralegal-analysis-stream.png"
+  src="/media/docs/chat/paralegal-analysis-stream.png"
   description="Paralegal AI streaming analysis in the conversation thread — file uploaded, status messages, extracted facts inline."
 />
 

--- a/src/data/docs/features/manage-matters.mdx
+++ b/src/data/docs/features/manage-matters.mdx
@@ -6,6 +6,8 @@ alt: "Manage matters in Blawby"
 author: "Paul Chris Luke"
 authorImage: "/images/logo.png"
 category: "features"
+group: "Matters"
+groupOrder: 30
 contentType: "guide"
 order: 50
 createdAt: "04/30/2026"
@@ -61,7 +63,7 @@ Discipline matters here. Logging at the end of each session, with a real descrip
 
 <DocPlaceholder
   kind="screenshot"
-  src="/docs/matters/time-entry-form.png"
+  src="/media/docs/matters/time-entry-form.png"
   description="Time entry form on the Work tab — start/end pickers, description, billable toggle, rate auto-applied from user role."
 />
 

--- a/src/data/docs/features/manage-matters.mdx
+++ b/src/data/docs/features/manage-matters.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Manage Matters and Case Data Efficiently in Blawby"
-desc: "How to use the Matters tab in Blawby to handle billing, time tracking, team assignments, and client communication for active cases."
+title: "Manage Matters in Blawby — Day-to-Day Workflow"
+desc: "The day-to-day matter workflow in Blawby — log time, track files, generate invoices from unbilled work, communicate with the client, and close cleanly."
 image: "/og-images/default.png"
 alt: "Manage matters in Blawby"
 author: "Paul Chris Luke"
@@ -9,86 +9,142 @@ category: "features"
 contentType: "guide"
 order: 50
 createdAt: "04/30/2026"
-updatedAt: "04/30/2026"
+updatedAt: "05/07/2026"
+lastVerified: "05/07/2026"
 tags:
   - Matters
-  - Billing
   - Time-Tracking
-  - Case-Management
+  - Billing
+  - Files
 keywords:
-  - Matter management
-  - Legal billing
+  - Manage matters Blawby
   - Time tracking law firm
-  - Blawby matters
-  - Law firm case management
-summary: "Use the Matters tab to manage active legal work, billing, time tracking, and client collaboration."
+  - Generate invoice from time
+  - Close matter Blawby
+summary: "Day-to-day matter workflow: log time, manage files, generate invoices, communicate, and close cleanly."
 faq:
-  - Question: "When does a matter appear in the Matters tab?"
-    answer: "A matter is created after intake acceptance, engagement completion, and payment flow progression in your Blawby workflow."
-  - Question: "Can more than one team member work the same matter?"
-    answer: "Yes. Add assignees so attorneys and staff can collaborate with appropriate access."
-  - Question: "Can clients add files and request updates?"
-    answer: "Yes. Clients can use their matter workflow to share information and follow updates."
+  - question: "When does a matter become active?"
+    answer: "After the client signs the engagement and any initial payment (retainer, flat fee) clears. Active matters are where day-to-day work happens."
+  - question: "Can I switch billing types mid-matter?"
+    answer: "Yes. Update billing type from the matter's Settings tab. Existing time entries and invoices keep their original rates; new entries follow the new type."
 schemaType: "HowTo"
 noindex: false
 ---
 
 # Manage Matters
 
-Once a client is onboarded, the Matters tab becomes your day-to-day command center. The goal is simple: keep legal work, billing, communication, and documents in one place.
+Once an engagement is accepted, the matter is your day-to-day home for the work — billing, files, communication, and the audit trail. This page is the operational workflow.
 
-## What the Matters Tab Is
+For the full structure (the seven tabs, the unbilled-summary → invoice flow, the client portal view, reassignment, status transitions), see [Matters Overview](/features/matters-overview).
 
-The Matters tab is where active client work is managed after intake, engagement, and payment steps are completed.
+## The daily rhythm
 
-## Billing and Invoicing
+Most attorneys settle into something like this:
 
-From the matter workflow, your team can:
+1. **Open the matter** when starting work.
+2. **Log time** at the end of the work session — start/end or duration, billable, with a one-line note.
+3. **Drop files** as you collect them. Drag and drop into the Files tab, or accept what the client uploads in chat.
+4. **Update notes** at decision points. The Notes tab is internal-only; use it for strategy and privileged work product.
+5. **Send an invoice** when the unbilled summary justifies it (monthly, on milestones, or when a retainer needs a top-up).
+6. **Communicate** through the matter's chat thread, not external email — keeps the audit trail intact.
 
-- Create invoices tied to the matter
-- Send payment requests
-- Track paid and unpaid balances
+## Logging time
 
-Why this matters: matter-based billing makes it easier to track financial status by case instead of by inbox thread.
+On the **Work** tab, click **Add time entry**. Each entry includes:
 
-## Time Tracking
+- Start/end times *or* duration.
+- A one-line description (will appear on invoices).
+- Billable / non-billable toggle.
+- The rate — pulled automatically from your role on the practice (attorney rate vs. admin rate). Override per matter in **Settings tab** if this matter has unique rates.
 
-For hourly matters, log time against the active matter so billing records match actual work delivered.
+Discipline matters here. Logging at the end of each session, with a real description, is what makes invoices fast and disputes rare.
 
-Why this matters: accurate time records reduce disputes and support cleaner invoicing.
+<DocPlaceholder
+  kind="screenshot"
+  src="/docs/matters/time-entry-form.png"
+  description="Time entry form on the Work tab — start/end pickers, description, billable toggle, rate auto-applied from user role."
+/>
 
-## Assignees and Team Access
+## Generating an invoice
 
-Assign the right team members to each matter so work is visible and responsibilities are clear.
+When you're ready to bill:
 
-Typical assignment model:
+1. Open the **Billing** tab.
+2. Review the **unbilled summary** — billable hours, expenses, flat-fee line items, retainer draws waiting to be billed.
+3. Click **Generate invoice**. The line items pull from the summary.
+4. Edit if needed — adjust descriptions, remove items, add a flat fee or expense.
+5. **Send**. The client gets an email with a Stripe-hosted pay button.
 
-- Attorney: legal strategy and approvals
-- Paralegal: document prep and follow-up
-- Admin/billing: invoicing and payment monitoring
+For retainer matters, the invoice draws from the retainer balance first; if there's a shortfall, the client pays the difference. When the balance gets low, send a top-up invoice from the same flow.
 
-Why this matters: clear assignees prevent communication gaps and missed tasks.
+## Files
 
-## Client View and Collaboration
+The **Files** tab is the matter's document store:
 
-In the client-facing matter flow, clients can:
+- Upload by drag-drop or click-to-upload.
+- Accept files the client uploads in chat (they appear here automatically).
+- Preview images and PDFs in-browser.
+- Up to 25 MB per file.
+- Every upload, download, and delete logs to the **Activity** tab.
 
-- Review matter-related updates
-- Add files and supporting documents
-- Use chat for status updates and questions
+Organize by folder if a matter accumulates dozens of documents. Most matters are fine with a flat list.
 
-Why this matters: a single shared matter channel reduces fragmented communication.
+## Internal notes vs. client communication
 
-## File Sharing
+Two separate surfaces — keep them straight:
 
-Use matter-level file exchange for documents tied to the case. Keep file requests specific so clients know exactly what to upload.
+- **Notes tab** — internal-only. Strategy, privileged work product, conflict notes, reminder pings. **Clients never see this**.
+- **Chat thread** — visible to both sides. Use this for everything that's part of the lawyer/client relationship.
 
-## Ongoing Chat
+If you accidentally put privileged material in chat, delete the message immediately and document the deletion in Notes. The Activity tab will show the chat-message deletion regardless.
 
-Use matter chat for ongoing updates, requests, and confirmations. Keep messages concise and action-focused so clients know what happens next.
+## Team collaboration
 
-## Next Step
+The team assigned to the matter (configured on the **Settings** tab) all see the same matter, with role-appropriate access:
 
-As your matters grow, keep trust and payout operations clean with a documented compliance workflow.
+- **Attorney** — strategy, engagement decisions, settlement-level calls.
+- **Paralegal** — document collection, scheduling, draft work.
+- **Billing/admin** — invoices, retainer top-ups, payment monitoring.
 
-[Read IOLTA Compliance Guide](/compliance/iolta-compliance)
+Activity logs show who did what — useful both for billing review and for handoffs.
+
+## Reassigning a matter
+
+Cases change hands. To reassign:
+
+1. Open the matter → **Settings** tab.
+2. Update the team — add new assignees, remove old ones.
+3. Add a Note explaining the handoff context.
+
+The new assignees pick up the full thread and timeline. Nothing is lost.
+
+## Closing a matter
+
+When work is complete:
+
+1. Confirm there's no unbilled time or expenses sitting on the Billing tab.
+2. Send the final invoice, including any remaining retainer reconciliation.
+3. Once the final invoice is paid, change status to **Closed** in the Settings tab.
+4. (Optional) Archive — the matter is read-only after this.
+
+Closed matters stay searchable in the directory; their time entries, files, and activity are preserved indefinitely for audit.
+
+## Common operational questions
+
+**Two attorneys logged time on the same matter at the same time.**
+Both entries log; rates apply per user role. The invoice will show both.
+
+**A client wants to dispute a time entry.**
+Open the matter's **Activity** tab — every entry is timestamped with the user who logged it and what description they wrote. Use this in the discussion; resolve in writing in the Notes tab.
+
+**An expense came in after the invoice was sent.**
+Add the expense; it'll show on the next unbilled summary. Don't edit a sent invoice — generate a follow-up.
+
+**The matter is going pro bono mid-flight.**
+Update billing type to **Pro bono** in Settings. Existing entries keep their billable status; toggle them to non-billable individually if you want to zero out the unbilled summary.
+
+## Next: trust transfers and payment exceptions
+
+For retainer matters, a trust-to-operating workflow keeps fund handling clean. Pair that with the failed-payment SOP for full operational coverage.
+
+[Read the Trust-to-Operating Transfer Workflow](/features/trust-to-operating-transfer-workflow)

--- a/src/data/docs/features/matters-overview.mdx
+++ b/src/data/docs/features/matters-overview.mdx
@@ -5,6 +5,8 @@ image: "https://imagedelivery.net/Frxyb2_d_vGyiaXhS5xqCg/527f8451-2748-4f04-ea0f
 author: "Paul Chris Luke"
 authorImage: "/images/logo.png"
 category: "features"
+group: "Matters"
+groupOrder: 30
 contentType: "guide"
 order: 45
 createdAt: "05/07/2026"
@@ -44,7 +46,7 @@ This page is the map: the seven tabs you'll see, what each one does, and how the
 
 <DocPlaceholder
   kind="video"
-  src="/docs/matters/walkthrough.mp4"
+  src="/media/docs/matters/walkthrough.mp4"
   description="45-second walkthrough of the matter detail panel — opening a matter, adding a time entry, generating an invoice from unbilled time."
 />
 
@@ -61,7 +63,7 @@ Either way, you land on the matter detail panel with the seven tabs across the t
 
 <DocPlaceholder
   kind="screenshot"
-  src="/docs/matters/tabs-annotated.png"
+  src="/media/docs/matters/tabs-annotated.png"
   description="Annotated MatterDetailPanel showing the seven tabs (Overview, Work, Billing, Files, Notes, Activity, Settings)."
 />
 
@@ -97,7 +99,7 @@ Where money becomes invoices.
 
 <DocPlaceholder
   kind="screenshot"
-  src="/docs/matters/billing-unbilled-summary.png"
+  src="/media/docs/matters/billing-unbilled-summary.png"
   description='Billing tab with the unbilled summary card highlighted and the "Generate invoice" CTA visible.'
 />
 

--- a/src/data/docs/features/matters-overview.mdx
+++ b/src/data/docs/features/matters-overview.mdx
@@ -1,0 +1,209 @@
+---
+title: "Matters Overview: Tabs, Time Tracking, Billing"
+desc: "How matters work in Blawby: the seven tabs, how time tracking rolls into invoices, and what your client sees in the portal — start to close."
+image: "https://imagedelivery.net/Frxyb2_d_vGyiaXhS5xqCg/527f8451-2748-4f04-ea0f-805a4214cd00/public"
+author: "Paul Chris Luke"
+authorImage: "/images/logo.png"
+category: "features"
+contentType: "guide"
+order: 45
+createdAt: "05/07/2026"
+updatedAt: "05/07/2026"
+lastVerified: "05/07/2026"
+tags:
+  - Matters
+  - Time-Tracking
+  - Billing
+  - Case-Management
+keywords:
+  - Blawby matters
+  - Legal matter management
+  - Time tracking law firm
+  - Unbilled summary invoice
+  - Client portal matters
+difficulty: "intermediate"
+prerequisites: ["send-engagement-and-collect-payment"]
+timeToComplete: "15 minutes"
+nextSteps: ["trust-to-operating-transfer-workflow"]
+schemaType: "HowTo"
+faq:
+  - question: "When is a matter created in Blawby?"
+    answer: "A matter is created automatically when an intake is accepted, or manually from the Matters page if you're capturing a matter that didn't start in Blawby."
+  - question: "Who can see and edit a matter?"
+    answer: "Members assigned to the matter — typically the attorney, paralegal, and billing/admin user — based on their role on the practice. Clients see a simplified view of their own matters in the client portal."
+  - question: "How are invoices tied to matters?"
+    answer: "Time entries, expenses, flat fees, and retainer draws all log to the matter. The Billing tab generates an invoice from those line items in one click."
+noindex: false
+---
+
+# Matters Overview
+
+Once an intake is accepted and an engagement is signed, the matter is the day-to-day home for the work. Notes, time entries, files, invoices, and activity all live on the matter and stay tied to the client.
+
+This page is the map: the seven tabs you'll see, what each one does, and how they connect.
+
+<DocPlaceholder
+  kind="video"
+  src="/docs/matters/walkthrough.mp4"
+  description="45-second walkthrough of the matter detail panel — opening a matter, adding a time entry, generating an invoice from unbilled time."
+/>
+
+## How a matter starts
+
+Two paths:
+
+1. **From an accepted intake.** The matter is created automatically when you accept an intake from the queue. Contact info, case summary, urgency, and any uploaded files carry forward.
+2. **From the Matters page directly.** Click **New matter**, fill the form, and assign the team. Use this for matters that didn't come through the widget (existing clients, referrals, walk-ins).
+
+Either way, you land on the matter detail panel with the seven tabs across the top.
+
+## The seven tabs
+
+<DocPlaceholder
+  kind="screenshot"
+  src="/docs/matters/tabs-annotated.png"
+  description="Annotated MatterDetailPanel showing the seven tabs (Overview, Work, Billing, Files, Notes, Activity, Settings)."
+/>
+
+### Overview
+
+The home tab. Shows:
+
+- Client info, parties, and short case summary.
+- Status pill — **Open**, **In progress**, **Closed**, or **Pro bono**.
+- The team assigned to the matter.
+- Documents the client uploaded during intake.
+- Quick actions: send a payment request, log time, send a message.
+
+### Work
+
+Where the legal work itself is tracked.
+
+- **Tasks and milestones** — what needs to happen next, by when, owned by whom.
+- **Notes** — internal thinking, client-call summaries, strategy memos.
+- **Time entries** — with start/end or duration, billable toggle, and the rate that applies (attorney vs. admin) pulled from the user's role.
+- **Work diary calendar** — a calendar view of logged time across the matter.
+
+The most common rhythm: log time at the end of each work session, write a one-line note describing what you did, and let the unbilled summary on the Billing tab roll up.
+
+### Billing
+
+Where money becomes invoices.
+
+- **Unbilled summary** — total billable hours, unbilled expenses, and any flat-fee or retainer line items waiting to be invoiced.
+- **Invoices** — every invoice ever issued on the matter, with status (Draft / Sent / Paid / Overdue).
+- **Generate invoice** — one click to roll the unbilled summary into an invoice. Edit line items, then send.
+- **Retainer balance** — for retainer matters, the balance and history of draws.
+
+<DocPlaceholder
+  kind="screenshot"
+  src="/docs/matters/billing-unbilled-summary.png"
+  description='Billing tab with the unbilled summary card highlighted and the "Generate invoice" CTA visible.'
+/>
+
+### Files
+
+Documents on the matter, organized by folder.
+
+- Upload from the lawyer side or accept files clients upload via chat or their portal.
+- Preview images and PDFs in-browser, download anything else.
+- 25 MB per file.
+- File events log to the Activity tab automatically.
+
+### Notes
+
+Internal-only notes, separate from client-visible communication. Use this for:
+
+- Privileged work product
+- Strategy threads between attorneys
+- Conflict notes that shouldn't be shared
+- Reminder pings to yourself before a hearing
+
+Clients never see the Notes tab.
+
+### Activity
+
+The audit trail. Every change on the matter logs here:
+
+- Time entry added or edited
+- Invoice created, sent, or paid
+- File uploaded or removed
+- Status changed
+- Note posted
+- Team assignment changed
+
+This is what you reach for when a client asks "what happened on July 14" or when you're putting evidence together in a billing dispute.
+
+### Settings
+
+Per-matter configuration:
+
+- Billing type — flat fee, hourly, retainer, or contingency. Can change as the matter evolves.
+- Billing rates — override the firm default if this matter has unique rates.
+- Team assignment — who's on the matter and at what role.
+- Status — Open / In progress / Closed / Pro bono.
+
+## Time tracking, end to end
+
+Time-to-invoice is the most-used path through the matter. Here's the full loop:
+
+1. **Log time** on the Work tab: start/end or duration, description, billable toggle.
+2. The entry uses your role's rate — attorney rate or admin rate, set on the firm or overridden per user.
+3. **Unbilled summary** on the Billing tab shows the running total.
+4. **Generate invoice** — entries become line items.
+5. **Send.** The client gets an email with a hosted Stripe payment link.
+6. **Status updates** roll back to the matter as the client views, pays, or lets the invoice age.
+
+If the matter has a retainer balance, the invoice draws from it before billing the client for the difference.
+
+## What the client sees
+
+Clients have a separate, simplified view of their own matters in the client portal — no time entries, no internal notes, no team-assignment internals.
+
+What they *do* see:
+
+- Matter overview with status and parties.
+- Invoices (and a one-tap pay button for unpaid ones).
+- Files they've uploaded plus any documents you've shared with them.
+- Engagement letter (if they signed one) and any updates.
+- A chat thread with the firm.
+
+Anything tagged internal-only (Notes, internal Activity entries) stays on the lawyer side.
+
+## Reassigning a matter
+
+Cases change hands. To reassign:
+
+1. Open the matter → **Settings** tab.
+2. Update the team — add the new assignees, remove who's no longer on it.
+3. Add a Note explaining the handoff.
+
+The new assignees pick up the full context: the timeline, all notes, all activity, all files. Nothing is lost in handoff.
+
+## Closing a matter
+
+When work is complete:
+
+1. Confirm there's no unbilled time or expenses sitting on the Billing tab.
+2. Send the final invoice.
+3. Once paid, change status to **Closed** in the Settings tab.
+4. (Optional) Archive — the matter is read-only after this.
+
+Closed matters stay searchable in the directory. Time entries, files, and activity are preserved for audit and reference.
+
+## Common questions
+
+**What if a matter switches billing types mid-way?**
+Update the billing type in Settings. Existing invoices and time entries don't change; new entries follow the new type. Common case: an uncontested family-law matter moves to litigation and switches from flat to hourly.
+
+**Can a matter have more than one client?**
+Yes — co-clients (e.g., two parties in a joint estate plan) are configured on the engagement letter and carry through to the matter.
+
+**Where do conflicts and jurisdiction checks live?**
+On the engagement, not the matter. By the time a matter exists, those checks have already been recorded.
+
+## Next: trust-to-operating transfers
+
+For retainer and trust-eligible matters, the matter's billing flow connects directly to your trust account. The transfer workflow keeps that clean.
+
+[Read the Trust-to-Operating Transfer Workflow](/features/trust-to-operating-transfer-workflow)

--- a/src/data/docs/features/review-and-triage-intake.mdx
+++ b/src/data/docs/features/review-and-triage-intake.mdx
@@ -6,6 +6,8 @@ alt: "Review and triage client intakes in Blawby"
 author: "Paul Chris Luke"
 authorImage: "/images/logo.png"
 category: "features"
+group: "Intake"
+groupOrder: 10
 contentType: "guide"
 order: 20
 createdAt: "04/30/2026"
@@ -40,7 +42,7 @@ This page walks through what you see in the queue, what to read on each submissi
 
 <DocPlaceholder
   kind="screenshot"
-  src="/docs/intake/queue.png"
+  src="/media/docs/intake/queue.png"
   description="IntakesPage queue with several submissions, urgency badges, and the New filter active."
 />
 
@@ -71,7 +73,7 @@ Open a submission to see the detail view (`IntakeDetailPage`). Read in this orde
 
 <DocPlaceholder
   kind="screenshot"
-  src="/docs/intake/detail-page-annotated.png"
+  src="/media/docs/intake/detail-page-annotated.png"
   description="IntakeDetailPage with the case summary, urgency badge, custom fields, and decision buttons annotated."
 />
 

--- a/src/data/docs/features/review-and-triage-intake.mdx
+++ b/src/data/docs/features/review-and-triage-intake.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Review and Triage Client Intakes"
-desc: "Learn how to review incoming intake submissions in Blawby and decide to accept, deny, or request more information."
+title: "Review and Triage Intakes — Accept, Decline, Ask AI"
+desc: "Triage intake submissions in Blawby's queue: read the AI summary, accept to create a matter, decline cleanly, or send the AI back for more info."
 image: "/og-images/default.png"
 alt: "Review and triage client intakes in Blawby"
 author: "Paul Chris Luke"
@@ -9,89 +9,134 @@ category: "features"
 contentType: "guide"
 order: 20
 createdAt: "04/30/2026"
-updatedAt: "04/30/2026"
+updatedAt: "05/07/2026"
+lastVerified: "05/07/2026"
 tags:
   - Intake
   - Triage
-  - Client-Review
+  - Queue
 keywords:
   - Review client intake
-  - Accept intake blawby
-  - Deny intake blawby
-  - Request more intake information
-summary: "Review new intake submissions and decide whether to accept, deny, or request more details in Blawby."
+  - Accept intake Blawby
+  - Decline intake Blawby
+  - Ask AI gather more information
+summary: "Triage new intake submissions from the IntakesPage queue and decide accept, decline, or ask AI for more info."
 faq:
-  - Question: "How quickly should we triage a new intake?"
-    answer: "Aim to review new submissions the same day whenever possible, so potential clients are not left waiting."
-  - Question: "Should we deny an intake immediately if information is missing?"
-    answer: "Usually no. If the matter seems potentially viable, request more details first so you can make a better decision."
-  - Question: "Can support staff handle triage before an attorney reviews it?"
-    answer: "Yes. Many firms use a paralegal or intake coordinator to do first-pass triage before attorney review."
+  - question: "How quickly should we triage a new intake?"
+    answer: "Same day. The first response time is the strongest predictor of conversion in legal intake."
+  - question: "Should we decline an intake immediately if information is missing?"
+    answer: "Usually no. If the matter looks viable, use 'Ask AI to gather more info' before declining. The widget continues the conversation and returns the intake to your queue with the missing facts filled in."
+  - question: "Can support staff handle triage before an attorney reviews it?"
+    answer: "Yes. Many firms have a paralegal or intake coordinator do first-pass triage; attorneys see only the ones that pass the initial filter."
 schemaType: "HowTo"
 noindex: false
 ---
 
 # Review and Triage Client Intakes
 
-Fast, consistent intake triage helps you protect attorney time and respond to serious matters quickly. In Blawby, triage is the decision point between a new submission and a real client conversation.
+Every new submission lands in your **Intakes** queue. Triage is the moment a submission becomes a matter — or doesn't.
 
-## Why Triage Matters
+This page walks through what you see in the queue, what to read on each submission, and the three actions available.
 
-Every new intake is a time decision. A good triage process helps your firm:
+<DocPlaceholder
+  kind="screenshot"
+  src="/docs/intake/queue.png"
+  description="IntakesPage queue with several submissions, urgency badges, and the New filter active."
+/>
 
-- Respond quickly to strong leads
-- Decline poor-fit matters professionally
-- Request missing details before committing attorney time
+## The queue
 
-## Where New Intakes Appear
+Open **Intakes** from your dashboard. The queue shows every recent submission with:
 
-In your Blawby dashboard, new submissions appear in your intake review area/queue for your team to process. Open the submission to view the details before taking action.
+- **Client name and contact**.
+- **Matter type** — what your template's matter-type field captured.
+- **Urgency badge** — low / medium / high (color-coded).
+- **AI-generated case summary** — a short title plus a one-paragraph gist.
+- **Submitted at** — relative time so you can spot stale items.
+- **Status pill** — New / In review / Accepted / Declined / Awaiting info.
 
-## What to Review Before You Decide
+Filter by status, search by name, sort by urgency. New + high-urgency submissions sit at the top by default.
 
-For each intake, review the core details submitted through the chat intake form, including:
+## What to read on a submission
 
-- Contact information
-- Matter type and short case summary
-- Timing/urgency context
-- Any additional information captured by your intake form
+Open a submission to see the detail view (`IntakeDetailPage`). Read in this order:
 
-If details are incomplete but the matter may be a fit, request more information instead of denying immediately.
+1. **Case summary** — the AI's short-form description. Sets context fast.
+2. **Urgency** — high-urgency matters often have hard deadlines (statute of limitations, court dates) and warrant a same-hour response.
+3. **Jurisdiction / location** — confirm you're admitted there. If not, your decision is "decline with referral note."
+4. **Contact** — name, email, phone.
+5. **Custom field answers** — anything your template asked beyond the standard fields.
+6. **Documents** — files the client uploaded (police reports, contracts, photos). Open inline.
+7. **Payment status** — if your template has a consultation fee, confirm it's marked paid before accepting.
 
-## Action 1: Accept the Intake
+<DocPlaceholder
+  kind="screenshot"
+  src="/docs/intake/detail-page-annotated.png"
+  description="IntakeDetailPage with the case summary, urgency badge, custom fields, and decision buttons annotated."
+/>
 
-Use **Accept** when the submission matches your practice and is ready for attorney follow-up.
+## Action 1 — Accept
 
-What happens next:
+Use **Accept** when the matter fits your practice and you have enough to take the next step.
 
-- The intake moves forward in your workflow
-- The conversation becomes available for direct lawyer/client communication
-- Your team can proceed with consultation and engagement steps
+What happens automatically:
 
-## Action 2: Deny the Intake
+- A **matter** is created with the contact info, case summary, urgency, and uploaded files carried forward.
+- The **conversation** thread becomes available for direct attorney/client communication.
+- The **client** is notified that their intake was accepted.
+- Your team receives an in-app and email/push notification (per your Notifications policy).
 
-Use **Deny** when the matter is outside scope, conflicts with your intake criteria, or is not a fit.
+Then move directly into the conversation — see [Join a Client Conversation](/features/join-client-conversation).
 
-What to keep in mind:
+## Action 2 — Decline
 
-- Use clear internal notes so your team understands why
-- Keep client-facing communication professional and brief when your workflow includes a decline response
+Use **Decline** when the matter is outside your scope, conflicts with another client, or isn't a fit for any other reason.
 
-## Action 3: Ask Blawby AI to Gather More Information
+What happens automatically:
 
-Use this when the intake is promising but incomplete.
+- The submission is closed and removed from the active queue.
+- The client is sent a clean, professional decline message (template-configurable in **Settings → Intake templates**).
+- An internal note can be added, visible only to your team.
 
-In this flow, Blawby AI continues the intake conversation with the potential client to collect missing details you need for a decision (for example: timeline, facts, or case context). Once the additional information is collected, the intake returns to your review queue for a final accept/deny decision.
+Best practice: keep client-facing decline messages brief. Save the reasoning for your internal note — that's where future referrals or conflict checks will look.
 
-## Practical Triage Standards
+## Action 3 — Ask AI to gather more info
 
-- Review new intakes at least once daily
-- Prioritize time-sensitive submissions first
-- Use consistent accept/deny criteria across staff
-- Prefer “request more info” when one key detail is missing
+Use this when the matter looks promising but is missing one or two facts you'd need to decide.
 
-## Next Step
+What happens:
 
-Once you accept an intake, move immediately into direct client communication.
+- The widget conversation reopens for the client.
+- The AI asks the specific follow-up questions you specified (or the standard enrichment-phase questions if you don't specify).
+- Once the client answers, the intake returns to your queue with status **Awaiting info → New**.
+- You triage again with the new context.
 
-[Join a Client Conversation](/features/join-client-conversation)
+This is the highest-converting third option — much better than declining a thin lead. Common follow-ups: court dates, opposing party, prior counsel, document availability, jurisdiction confirmation.
+
+## Practical triage standards
+
+- **Review new intakes at least daily** — same morning is better.
+- **Prioritize high-urgency first**, regardless of submitted-at order.
+- **Use consistent accept/decline criteria** across attorney and staff (write them down — see day-one checklist).
+- **Default to "ask AI for more info"** when one key detail is missing rather than declining outright.
+- **Decline cleanly** — short, professional, no legal advice in the message.
+
+## Edge cases
+
+**Two intakes from the same client.**
+Common when a client doesn't see the confirmation. Accept the more complete one; decline the duplicate with an internal note linking them.
+
+**Intake from a jurisdiction you don't cover.**
+Decline with a referral note in your internal record. If you have a partner firm, share the referral path in a personal email — don't put referral promises in the auto-decline template.
+
+**Intake with a paid consultation fee that you have to decline.**
+Decline, then refund the consultation fee from the linked invoice. The refund processes through Stripe and notifies the client.
+
+**Possible conflict.**
+Decline with conflict status noted. Make sure your template's standard decline language doesn't claim or deny representation of opposing parties.
+
+## Next: join the client conversation
+
+When you accept, the next step is a fast, clear first message in the conversation thread.
+
+[Continue to Join a Client Conversation](/features/join-client-conversation)

--- a/src/data/docs/features/send-engagement-and-collect-payment.mdx
+++ b/src/data/docs/features/send-engagement-and-collect-payment.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Send an Engagement and Collect Payment"
-desc: "How to send an engagement letter through Blawby, get client acceptance, and collect your first payment for the matter."
+title: "Send an Engagement and Collect Payment in Blawby"
+desc: "Send a structured engagement letter from a matter, get client acceptance, and collect the retainer or initial fee — all in the same thread."
 image: "/og-images/default.png"
 alt: "Send engagement and collect payment in Blawby"
 author: "Paul Chris Luke"
@@ -9,73 +9,130 @@ category: "features"
 contentType: "guide"
 order: 40
 createdAt: "04/30/2026"
-updatedAt: "04/30/2026"
+updatedAt: "05/07/2026"
+lastVerified: "05/07/2026"
 tags:
   - Engagement
   - Payment
   - Retainer
-  - Billing
+  - Stripe
 keywords:
-  - Send engagement letter
-  - Collect retainer
-  - Client accepts engagement
-  - Law firm engagement workflow
-summary: "Send engagement terms, collect client acceptance, and request payment in Blawby."
+  - Send engagement letter Blawby
+  - Collect retainer Blawby
+  - Engagement plus payment law firm
+  - Stripe payment in chat
+summary: "Send the structured engagement, get acceptance, and collect the retainer or initial fee in one flow."
 faq:
-  - Question: "What is an engagement in Blawby?"
-    answer: "It is the agreement step that confirms representation terms before work begins."
-  - Question: "Can we collect consultation or retainer payment right after acceptance?"
-    answer: "Yes. After engagement acceptance, your payment request flow can proceed for consultation fees, flat fees, or retainers."
-  - Question: "How does IOLTA handling fit here?"
-    answer: "Blawby routes billing and payouts through the trust/operating framework configured in your account."
+  - question: "What's in a Blawby engagement letter?"
+    answer: "Four sections: representation (scope, jurisdictions, parties), fees (billing type, rates, retainer amount), risk review (conflict and jurisdiction status), and acknowledgments (legal language). Pre-filled from intake and matter context, edited by you, signed by the client."
+  - question: "Can the client pay the retainer right after signing?"
+    answer: "Yes. After the client signs, they're redirected to a Stripe-hosted payment for any retainer or initial fee defined on the engagement."
+  - question: "Where do those funds land?"
+    answer: "Per your trust-routing configuration. If trust routing is set up, retainer dollars go to your trust account in full; processing fees are charged separately to your operating-account card."
 schemaType: "HowTo"
 noindex: false
 ---
 
 # Send an Engagement and Collect Payment
 
-This step turns a promising intake into an active client relationship. Clear engagement terms and timely payment collection reduce misunderstandings and help you start work faster.
+This is the moment a qualified intake becomes a paying matter. Blawby treats the engagement as a **structured object** — four sections you edit, not a free-text PDF you re-create from scratch every time. After the client signs, payment collection is built into the same flow.
 
-## What Engagement Means in Blawby
+For the deeper engagement model (the four sections, the lifecycle, conflict and jurisdiction status, immutability, amendments), see [Engagements Overview](/features/engagements-overview). This page is the operational version: how you send one, what the client experiences, and how payment lands.
 
-In this workflow, engagement is the formal agreement step between your firm and the potential client. It confirms representation terms before ongoing matter work begins.
+## What you'll edit before sending
 
-## Send Engagement from the Conversation Workflow
+When you click **Create engagement** from a matter, Blawby pre-fills the four sections from the intake answers, the matter context, and your firm defaults. You review and edit:
 
-After intake acceptance and initial chat:
+- **Representation** — scope summary, included/excluded services, parties, jurisdiction notes.
+- **Fees** — billing type (flat / hourly / retainer / contingency), rates, retainer amount, payment frequency, fee notes.
+- **Risk review** — conflict status, jurisdiction status, risk notes, open questions.
+- **Acknowledgments** — your firm's standard legal language (configured once in practice settings).
 
-1. Open the client conversation in Blawby.
-2. Start the engagement step from that workflow.
-3. Send the engagement letter/agreement to the client for review.
+Pay particular attention to:
 
-Keep your message clear: what they are agreeing to, what happens after acceptance, and what payment is required next.
+- The scope's **excluded services** — most scope-creep disputes start with something the engagement didn't explicitly call out as excluded.
+- The **fees section** — the billing type set here flows automatically to the matter once the engagement is accepted.
+- **Risk review** — if conflict or jurisdiction status is unclear, hold the engagement in Draft until it is.
 
-## What the Client Receives
+<DocPlaceholder
+  kind="screenshot"
+  src="/docs/engagements/draft-editor.png"
+  description="Engagement draft editor with the four sections expanded — representation, fees, risk review, acknowledgments."
+/>
 
-The client receives the engagement request in their Blawby flow, reviews the terms, and accepts to proceed.
+## Send
 
-## Collect Payment After Acceptance
+When the four sections look right, click **Send**.
 
-After acceptance, request the appropriate payment type for your matter setup:
+What happens:
 
-- Consultation fee
-- Flat fee
-- Retainer
+- The engagement status moves from **Draft** to **Sent**.
+- The client receives an email and (if subscribed) a push notification with a link to the review page.
+- The notification points at a clean, branded review surface — no Blawby login required.
 
-This keeps engagement and payment connected so your team can see progress clearly.
+## What the client experiences
 
-## Where Funds Route (Operating vs Trust)
+The client opens the engagement on `ClientEngagementReviewPage`:
 
-Payment routing follows your Blawby payment and IOLTA configuration. This is why account setup and trust rules should be finalized before live client work.
+1. They read the **client summary** at the top — matter, location, goals, parties.
+2. They scroll through representation, fees, risk acknowledgments, and the legal language.
+3. If they have questions, they reply in the chat thread (their messages route back to the matter).
+4. They sign with a typed signature; the signature, IP address, and timestamp are recorded.
+5. **On acceptance**, they're redirected to pay any retainer or initial fee defined in the Fees section.
 
-If you handle unearned client funds, ensure trust routing is configured before collecting those amounts.
+<DocPlaceholder
+  kind="video"
+  src="/docs/engagements/client-acceptance.mp4"
+  description="Client opens the engagement, reviews the four sections, signs, and is redirected to Stripe for retainer payment."
+/>
 
-## What Happens After Payment
+## Payment after acceptance
 
-Once engagement is accepted and payment is completed, the client moves into active matter management in Blawby.
+Whatever you put in the **Fees** section — retainer amount, flat fee, contingency cost-deposit — becomes the immediate payment ask after the client signs.
 
-## Next Step
+The Stripe-hosted payment surface accepts:
 
-Now manage the active case from the Matters tab, including billing, time, team access, files, and ongoing updates.
+- **Card** — instant.
+- **ACH** — settles in a few business days; the matter activates on settlement.
 
-[Manage Matters](/features/manage-matters)
+Routing follows your practice's trust-routing configuration:
+
+- **Trust-routed engagements** (most retainers): the gross amount lands in your trust account; Blawby never deducts fees from those dollars. Processing fees are charged separately to your operating-account card.
+- **Operating-routed engagements** (flat fees that aren't trust-eligible, contingency cost deposits where local rules permit): the amount lands in your operating account net of Stripe's standard processing.
+
+[Read the IOLTA Compliance Guide](/compliance/iolta-compliance) for more on how this fee model keeps trust dollars whole.
+
+## What changes once payment clears
+
+- The matter status moves to **active**.
+- The billing type set on the engagement is applied to the matter automatically.
+- The retainer balance (for retainer matters) shows on the matter's Billing tab.
+- Time logged from this point can roll into invoices that draw from the retainer balance.
+- Notifications fire to your team via in-app, email, and push.
+
+## If the client declines
+
+The engagement status moves to **Declined**. The matter doesn't activate. Your options:
+
+- **Edit and resend** — adjust scope or fees, send a new version. The original Declined record is preserved in the matter's audit trail.
+- **Close the matter** — if the decline is final.
+
+## Common scenarios
+
+**Scope expansion mid-matter.**
+Don't edit the existing engagement (it's immutable once accepted). Create a **new engagement** that references the prior one. The client signs the amendment the same way.
+
+**Retainer paid by ACH and settlement is pending.**
+The matter waits to activate until Stripe confirms settlement (a few business days). Status during that window: engagement Accepted, payment Pending, matter Pending Activation.
+
+**Contingency engagement with no upfront payment.**
+Skip the retainer field. The engagement still gets signed; payment collection happens at settlement.
+
+**Joint engagement with co-clients.**
+Each co-client signs separately. The engagement activates only when all required signatures are in.
+
+## Next: manage the active matter
+
+Once the engagement is accepted and any initial payment clears, the matter is active. All billable work, files, and communication live there.
+
+[Continue to Matters Overview](/features/matters-overview)

--- a/src/data/docs/features/send-engagement-and-collect-payment.mdx
+++ b/src/data/docs/features/send-engagement-and-collect-payment.mdx
@@ -6,6 +6,8 @@ alt: "Send engagement and collect payment in Blawby"
 author: "Paul Chris Luke"
 authorImage: "/images/logo.png"
 category: "features"
+group: "Engagements"
+groupOrder: 20
 contentType: "guide"
 order: 40
 createdAt: "04/30/2026"
@@ -56,7 +58,7 @@ Pay particular attention to:
 
 <DocPlaceholder
   kind="screenshot"
-  src="/docs/engagements/draft-editor.png"
+  src="/media/docs/engagements/draft-editor.png"
   description="Engagement draft editor with the four sections expanded — representation, fees, risk review, acknowledgments."
 />
 
@@ -82,7 +84,7 @@ The client opens the engagement on `ClientEngagementReviewPage`:
 
 <DocPlaceholder
   kind="video"
-  src="/docs/engagements/client-acceptance.mp4"
+  src="/media/docs/engagements/client-acceptance.mp4"
   description="Client opens the engagement, reviews the four sections, signs, and is redirected to Stripe for retainer payment."
 />
 

--- a/src/data/docs/features/set-up-client-intake.mdx
+++ b/src/data/docs/features/set-up-client-intake.mdx
@@ -5,6 +5,8 @@ image: "https://imagedelivery.net/Frxyb2_d_vGyiaXhS5xqCg/527f8451-2748-4f04-ea0f
 author: "Paul Chris Luke"
 authorImage: "/images/logo.png"
 category: "features"
+group: "Intake"
+groupOrder: 10
 contentType: "guide"
 order: 10
 createdAt: "02/15/2024"
@@ -67,7 +69,7 @@ Most setup time goes here. Don't over-stuff required fields — the shorter the 
 
 <DocPlaceholder
   kind="screenshot"
-  src="/docs/intake/template-list.png"
+  src="/media/docs/intake/template-list.png"
   description="IntakeTemplatesPage list view, with one default template and the New template CTA visible."
 />
 

--- a/src/data/docs/features/set-up-client-intake.mdx
+++ b/src/data/docs/features/set-up-client-intake.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Set Up Client Intake Workflows for Your Law Firm"
-desc: "Set up client intake in Blawby so your team can capture better submissions, triage faster, and move qualified leads forward."
+title: "Set Up Client Intake — Widget, Template, Triage"
+desc: "End-to-end intake setup in Blawby: install the widget, configure your intake template, route notifications, and set up triage so submissions move."
 image: "https://imagedelivery.net/Frxyb2_d_vGyiaXhS5xqCg/527f8451-2748-4f04-ea0f-805a4214cd00/public"
 author: "Paul Chris Luke"
 authorImage: "/images/logo.png"
@@ -8,150 +8,121 @@ category: "features"
 contentType: "guide"
 order: 10
 createdAt: "02/15/2024"
-updatedAt: "02/15/2024"
+updatedAt: "05/07/2026"
+lastVerified: "05/07/2026"
 tags:
   - Client-Intake
-  - Client-Management
-  - Workflows
-  - Automation
+  - Setup
+  - Widget
+  - Notifications
 keywords:
-  - Blawby client intake setup
-  - Legal intake workflow
-  - Law firm intake process
-  - Custom intake form blawby
+  - Set up Blawby client intake
+  - Legal intake widget
+  - Intake notification routing
+  - Law firm intake configuration
 difficulty: "intermediate"
 prerequisites: ["create-practice-account"]
-timeToComplete: "45 minutes"
+timeToComplete: "30 minutes"
 nextSteps: ["review-and-triage-intake"]
 schemaType: "HowTo"
 faq:
-  - Question: "How do I create custom intake forms?"
-    answer: "Use the intake form builder in your dashboard to create custom fields and validation rules for your specific practice needs."
-  - Question: "Can I automate client onboarding?"
-    answer: "Yes, Blawby supports automated workflows for client onboarding, document signing, and initial consultation scheduling."
+  - question: "Do I need a website to use Blawby intake?"
+    answer: "No. You can share your widget URL directly in email or text. The script tag is for embedding on a site you control."
+  - question: "Where do I configure intake fields?"
+    answer: "In Settings → Intake templates. See the Intake Templates page for the full field model — required vs. enrichment, conditional logic, consultation fees."
+  - question: "Who gets notified when a new intake arrives?"
+    answer: "Whichever team members you've enabled intake notifications for in Settings → Notifications. Notifications fan out to in-app, email, and (optionally) push."
 noindex: false
 ---
 
 # Set Up Client Intake
 
-Client intake is where first impressions and operational quality meet. A clear intake process helps you respond faster, collect the right details the first time, and avoid back-and-forth that slows down new matters. This guide walks you through a practical dashboard setup so your team can move from inquiry to qualified client without chaos.
+Intake in Blawby has four moving pieces: the **widget** clients fill out, the **template** that defines what's collected, the **notification policy** that gets a human looking at it, and the **triage flow** that turns a submission into an active matter.
 
-## Why Client Intake Matters
+This page walks through all four end-to-end. Each section links to a deeper reference for the part that's most often customized.
 
-When intake is inconsistent, firms lose time and often lose good clients. When it is consistent, your staff knows exactly what to do, prospective clients know what to expect, and attorneys get cleaner information before a consultation.
+## 1. The widget — what your clients see
 
-Blawby helps you:
+The widget is the embeddable chat surface. Clients open it from your website, your widget URL, or any link you share. The AI walks them through your intake template, collects files when needed, optionally takes a consultation fee, and submits to your queue.
 
-- Reduce manual admin during new-client onboarding
-- Improve response speed with structured intake details
-- Keep records cleaner for billing and compliance workflows
-- Scale lead handling without creating team confusion
+What it supports out of the box:
 
-## Getting Started
+- **18 languages** with full RTL for Arabic. Auto-detects browser language; clients can switch.
+- **File uploads** up to 25 MB per file (images, video, audio, PDF, Word).
+- **Conditional fields** — the AI only asks follow-ups when a parent answer matches.
+- **Practice branding** — your firm's name, logo, and accent color, all set in Settings.
 
-### Before You Begin
+For installation, see [Install the Chat Widget](/ai-chat/install-chat-widget). The fastest path is sharing your widget URL directly; embedding the script on your firm site is a 5-minute addition you can do later.
 
-You'll need:
+## 2. The template — what the AI collects
 
-- Active Blawby practice account
-- Admin access to intake settings
-- A basic decision on who owns intake in your firm (attorney, paralegal, or office manager)
+The intake template is the script the AI follows. It defines:
 
-### Step 1: Configure Intake Forms
+- **Required fields** that gate submission.
+- **Enrichment fields** offered after submission as "strengthen your case."
+- **Consultation fee** (optional) charged before submission.
+- **Legal disclaimer** shown once before contact collection.
 
-Your intake form should collect just enough to qualify a matter and move to the next step. Overly long forms increase drop-off.
+Most setup time goes here. Don't over-stuff required fields — the shorter the required list, the higher the completion rate. See [Intake Templates](/features/intake-templates) for the full model, conditional-logic syntax, and a fee-gating walkthrough.
 
-In your dashboard:
+<DocPlaceholder
+  kind="screenshot"
+  src="/docs/intake/template-list.png"
+  description="IntakeTemplatesPage list view, with one default template and the New template CTA visible."
+/>
 
-1. Open intake settings and choose your primary practice areas.
-2. Start with core fields every matter needs (name, phone, email, issue summary, jurisdiction).
-3. Add a small set of practice-specific questions (for example, case type and urgency).
-4. Mark only truly required questions as required.
-5. Save and submit a test intake yourself.
+## 3. Notifications — make sure a human sees it fast
 
-Why this matters: shorter, focused forms increase completions and give your team better first-contact context.
+A new intake is only as useful as the speed of the first response. Configure who gets pinged in **Settings → Notifications**.
 
-### Step 2: Set Up Client Management
+| Channel | Use it for |
+|---|---|
+| **In-app** | Every team member; this is the bell-icon count in the dashboard. |
+| **Email** | At least the intake owner, ideally a backup too. |
+| **Push (OneSignal)** | When you want phone-buzz speed. Each user opts in from their own device. |
 
-Once intake data is captured, your team needs a consistent way to review and act.
+Define a **backup intake owner** for after-hours and vacation coverage. A new submission with no human looking at it for 24 hours is a lead lost to the next firm.
 
-In your dashboard:
+## 4. Triage — turn submissions into matters
 
-1. Define your lead status stages (for example: New Inquiry, Needs Review, Qualified, Not a Fit).
-2. Confirm which intake fields should appear in the client profile.
-3. Set ownership rules so each new submission has a responsible team member.
-4. Use the client timeline to keep notes and communications in one place.
+When an intake arrives, the queue lives at **Intakes** in your dashboard. From the detail view, your three options are:
 
-Why this matters: consistent status and ownership rules prevent missed follow-ups and duplicated work.
+- **Accept** — opens the conversation thread and creates the matter; you take it from there.
+- **Decline** — politely closes the loop with the prospective client.
+- **Ask AI to gather more info** — sends the conversation back to the widget for follow-up questions before you decide.
 
-### Step 3: Automate Workflows
+For the full triage workflow see [Review and Triage Client Intakes](/features/review-and-triage-intake). The "ask for more info" flow is especially useful for matters that look promising but are missing one or two critical facts.
 
-Automation should reduce repetitive admin, not add complexity. Start with two or three automations and expand later.
+## Best practices
 
-Recommended first automations:
+### Template
 
-1. Notify the intake owner when a new qualified submission arrives.
-2. Send an acknowledgment message to the prospective client.
-3. Create a follow-up reminder if no action is taken within one business day.
-4. Route urgent matters for same-day review.
+- **Keep the required list short.** Five fields or fewer.
+- **Use conditional logic.** Fewer questions on screen = higher completion.
+- **Test on mobile.** Most intake submissions come from phones.
+- **Set a fee only if it's part of your policy.** Gating on a $0 charge is wasted friction.
 
-Why this matters: quick response time is often the difference between signing a matter and losing it to another firm.
+### Notifications
 
-## Best Practices
+- **One primary, one backup.** Single point of failure on intake notifications is the most common operational gap on day two.
+- **Push for speed, email for record.** Use both.
+- **Re-check after vacations.** People silence push and forget to re-enable it.
 
-### Form Design
+### Triage
 
-- **Keep forms short**: Ask only what your team needs to take the next step
-- **Use plain language**: Write questions the way clients naturally speak
-- **Use conditional questions**: Show relevant follow-ups based on matter type
-- **Test from a phone**: Many clients submit intake from mobile devices
+- **Define accept/decline criteria in writing.** Hold weekly debriefs the first month.
+- **Use "ask AI for more info" for borderline submissions** — it's higher-conversion than declining a thin lead.
+- **Move accepted intakes to a matter the same day.** Stale intakes go cold fast.
 
-### Data Management
+## Common pitfalls
 
-- **One source of truth**: Keep intake details in the client record, not scattered across inboxes
-- **Consistent naming**: Use the same labels for status and urgency across the team
-- **Timeline discipline**: Add notes for key decisions and contact attempts
+- **No backup intake owner** — the most common day-two problem.
+- **Required fields a client can't reasonably answer.** "Is this negligence?" is for the consult, not the form.
+- **Inconsistent triage criteria across staff** — you'll get conflicting client experiences fast.
+- **Intake template never revisited** — review monthly for fields that consistently come back empty.
 
-### Automation Rules
+## Next: triage submissions
 
-- **Escalate urgent matters**: Route high-priority submissions to immediate review
-- **Set response SLAs**: Define internal deadlines for first outreach
-- **Review weekly**: Track where intakes stall and adjust process steps
+Once your widget is live and notifications are routing, the queue starts filling up. Move to triage.
 
-## Common Intake Mistakes to Avoid
-
-- Asking for too much information before trust is built
-- Leaving “new inquiry” submissions unassigned
-- Using inconsistent status names between team members
-- Failing to define who follows up and when
-
-## Troubleshooting
-
-### Form completion is low
-
-- Shorten required questions
-- Move non-essential questions to consultation prep
-- Clarify the benefit of completing intake in your opening message
-
-### Team follow-up is inconsistent
-
-- Assign one owner for each new submission
-- Set automatic reminders for untouched leads
-- Use one agreed status workflow across the firm
-
-### Intake quality is poor
-
-- Add one or two qualification questions tied to your practice areas
-- Include a required “brief summary” field
-- Review submissions weekly and refine weak questions
-
-## Next Steps
-
-Your intake process is now structured for faster response and better lead quality. Next, connect intake to payment readiness so qualified leads can move directly into paid consultations and invoicing.
-
-1. Train your team on status and ownership rules.
-2. Test your form from desktop and mobile.
-3. Review first-response time after one week.
-4. Improve any step where leads are stalling.
-
-[Continue to Accept Your First Payment](/quick-start/accept-first-payment)
+[Continue to Review and Triage Client Intakes](/features/review-and-triage-intake)

--- a/src/data/docs/features/trust-to-operating-transfer-workflow.mdx
+++ b/src/data/docs/features/trust-to-operating-transfer-workflow.mdx
@@ -5,6 +5,8 @@ image: "https://imagedelivery.net/Frxyb2_d_vGyiaXhS5xqCg/527f8451-2748-4f04-ea0f
 author: "Paul Chris Luke"
 authorImage: "/images/logo.png"
 category: "features"
+group: "Trust & Compliance"
+groupOrder: 40
 contentType: "guide"
 order: 20
 createdAt: "04/30/2026"

--- a/src/data/docs/quick-start/accept-first-payment.mdx
+++ b/src/data/docs/quick-start/accept-first-payment.mdx
@@ -1,7 +1,6 @@
 ---
-title: "Accept Your First Payment"
-metaTitle: "Accept Your First Payment — Blawby Payments"
-desc: "Set up Blawby payments, connect bank accounts, and collect your first client payment with trust-safe routing."
+title: "Accept Your First Payment with Stripe Connect"
+desc: "Connect Stripe to your Blawby practice in two checkpoints, configure trust vs. operating routing, and send your first invoice from a matter."
 image: "https://imagedelivery.net/Frxyb2_d_vGyiaXhS5xqCg/527f8451-2748-4f04-ea0f-805a4214cd00/public"
 author: "Paul Chris Luke"
 authorImage: "/images/logo.png"
@@ -9,118 +8,147 @@ category: "quick-start"
 contentType: "guide"
 order: 30
 createdAt: "02/10/2024"
-updatedAt: "02/10/2024"
+updatedAt: "05/07/2026"
+lastVerified: "05/07/2026"
 tags:
   - Payments
+  - Stripe-Connect
+  - Trust-Account
   - Setup
-  - Configuration
 keywords:
-  - Accept first payment blawby
-  - Law firm payment setup
-  - Connect trust account payments
-  - Legal client payment processing
-  - First invoice payment
+  - Connect Stripe Blawby
+  - Law firm Stripe Connect
+  - Trust account routing law firm
+  - First invoice law firm
+  - Blawby payments setup
 difficulty: "beginner"
 prerequisites: ["create-practice-account"]
 timeToComplete: "15 minutes"
 nextSteps: ["set-up-client-intake"]
 schemaType: "HowTo"
 faq:
-  - Question: "How long does it take to set up payment processing?"
-    answer: "Payment processing setup takes about 15 minutes. Bank account verification may take 1-2 business days, but you can start accepting payments immediately."
-  - Question: "What payment methods can I accept?"
-    answer: "You can accept credit/debit cards, bank transfers (ACH), and set up payment plans. All methods are IOLTA compliant for trust accounts."
+  - question: "Do I need a separate bank account to start?"
+    answer: "Stripe Connect handles bank linking on Stripe's side — you don't enter routing or account numbers in Blawby. If your practice will hold client funds, you'll separately configure trust routing once Stripe is connected."
+  - question: "How long does it take to start collecting payments?"
+    answer: "About 15 minutes for the two Stripe Connect checkpoints. Charges become available as soon as the second checkpoint clears; payouts may take a few business days for new accounts."
+  - question: "Are processing fees deducted from the trust account?"
+    answer: "No. Blawby is built so processing and platform fees never come out of trust. Fees are charged separately to a card linked to your operating account."
 noindex: false
 ---
 
 # Accept Your First Payment
 
-Your first successful payment confirms your setup is working and your firm can collect funds without manual follow-up.
+Blawby uses **Stripe Connect** for payments. You don't enter bank account numbers in Blawby — you connect to Stripe, and Stripe handles the bank link, identity verification, and payouts. Your job in Blawby is to confirm the connection and configure trust vs. operating routing.
 
-## Before You Begin
+This page covers both checkpoints, plus how to send your first invoice from a matter.
 
-You'll need:
+<DocPlaceholder
+  kind="video"
+  src="/docs/payments/stripe-connect.mp4"
+  description="60-second walkthrough of the two Stripe Connect checkpoints in Blawby — link bank, enable charges — followed by sending the first invoice."
+/>
 
-- Active Blawby practice account
-- Business bank account information
-- Business details (EIN, business address)
-- A team member responsible for billing setup
+## The two Stripe Connect checkpoints
 
-## Step 1: Connect Your Bank Account
+Blawby's onboarding shows two checkpoints in your dashboard. Both must clear before your firm can collect.
 
-1. Log into your Blawby dashboard
-2. Go to **Settings → Payments**
-3. Click **Connect Bank Account**
-4. Enter routing number, account number, account type, and account holder name
+### Checkpoint 1 — Link bank account
 
-5. Blawby will make two small deposits (under $1.00)
-6. Check your bank account in 1-2 business days
-7. Enter the deposit amounts in your dashboard
-8. Confirm your account is verified
+1. Open **Settings → Payments**.
+2. Click **Connect Stripe**.
+3. You'll be redirected to Stripe's hosted onboarding to confirm:
+   - Business type and EIN
+   - Beneficial-owner / representative details
+   - The bank account you want payouts to land in
+4. When you complete Stripe's flow, you're redirected back. The first checkpoint shows **Linked**.
 
-Why this matters: verified payout details reduce failed transfers and payout delays.
+> **What's happening here.** Stripe is creating a connected account for your firm. Blawby stores only the connected-account ID; sensitive bank details live with Stripe. This is what keeps Blawby out of PCI and banking-secrecy scope on your behalf.
 
-## Step 2: Configure Payment Methods
+### Checkpoint 2 — Enable charges
 
-Enable the payment methods your clients use most:
+Stripe verifies your identity and business documents in the background. This usually takes a few minutes for low-risk firms; occasionally longer if Stripe wants additional documentation.
 
-- Credit/debit cards for convenience and faster completion
-- ACH for clients who prefer bank transfer
+When Stripe approves, the second checkpoint flips to **Charges enabled**. You can now:
 
-If available in your dashboard, review default payment limits and set limits that match your matter sizes.
+- Send invoices that include a Stripe-hosted pay button
+- Collect consultation fees on intake (if your template uses one)
+- Generate pre-filled payment links
 
-Why this matters: offering both cards and ACH increases completion rates and reduces client friction.
+If charges stay pending, open the Stripe dashboard — Stripe will list any documents it still needs. You don't need to re-do anything in Blawby; the checkpoint clears automatically once Stripe approves.
 
-## Step 3: IOLTA Trust Account Setup
+<DocPlaceholder
+  kind="screenshot"
+  src="/docs/payments/stripe-checkpoints.png"
+  description="Stripe checkpoint card in Settings → Payments — checkpoint 1 (Linked), checkpoint 2 (Charges enabled)."
+/>
 
-If you hold unearned client funds, set up your IOLTA trust account:
+## Trust vs. operating routing
 
-1. Go to **Settings → Trust Accounts**
-2. Click **Add Trust Account**
-3. Enter trust account details and confirm account type
-4. Review routing rules for trust and operating funds
+If your practice ever holds unearned client funds (retainers, settlement deposits, court filing-fee deposits), configure trust routing now — *before* you collect anything that should land in trust.
 
-Why this matters: correct trust setup protects client funds and reduces compliance risk.
+### How Blawby keeps trust dollars whole
 
-## Step 4: Create Your First Invoice
+Blawby's fee model is built for trust compliance:
 
-1. Go to **Payments → Create Invoice** (or create from a client profile)
-2. Enter client information:
-   - Client name and contact details
-   - Matter description
+- **Trust-eligible payments** route to your trust account in full — Blawby never deducts fees from those dollars.
+- **Processing and platform fees** are billed separately to a card you connect to your operating account.
 
-3. Add line items:
-   - Service description
-   - Quantity or hours
-   - Rate or flat amount
+This is the difference between Blawby and a generic processor that nets fees off the top: with Blawby, the trust account always receives the gross amount.
 
-4. Set payment terms:
-   - Due date
-   - Accepted payment methods
+### Setup
 
-5. Preview and send the invoice
+1. Open **Settings → Payments → Trust routing**.
+2. Add the trust-account details Stripe should pay to. (You'll usually do this through Stripe's flow with a separate connected account or routing rule, depending on how your firm structures trust.)
+3. Add the operating-account card that fees will be billed to.
+4. Confirm. From this point, retainer and trust-eligible invoices route automatically.
 
-## Next Steps
+If you don't hold client funds, leave trust routing off. All payments will land in your operating account.
 
-Your payment setup is now ready for live use. Next, make sure your internal process is clear so your team handles successful, failed, and delayed payments consistently.
+[Read the IOLTA Compliance Guide](/compliance/iolta-compliance) for more on how this fee model works.
 
-1. Send your first live invoice.
-2. Confirm payment alerts reach the right person.
-3. Review payout timing in your dashboard.
-4. Document who owns billing follow-up in your firm.
+## Send your first invoice from a matter
 
-## Need Help?
+The simplest first-payment path: log a few minutes of time on a matter, then generate an invoice.
 
-If you encounter payment processing issues:
+1. Open or create a **matter** for the client. (See [Matters Overview](/features/matters-overview).)
+2. On the **Work** tab, add a time entry — start/end or duration, billable, with a short description.
+3. Switch to the **Billing** tab. The **unbilled summary** card shows your total billable hours plus any expenses.
+4. Click **Generate invoice**. Edit line items, add a flat fee or retainer draw if relevant, then **Send**.
+5. The client gets an email with a hosted Stripe pay link. They can pay by card or ACH without creating an account.
+6. The invoice flips to **Paid** automatically when payment clears. Notifications fire to your team via in-app, email, and push (OneSignal).
 
-- **Payment Support**: [Blawby Help](/help)
-- **Compliance Resources**: [IOLTA Compliance Guide](/compliance/iolta-compliance)
-- **Operations Playbook**: [Failed Payment & Chargeback SOP](/features/failed-payment-and-chargeback-sop)
+<DocPlaceholder
+  kind="screenshot"
+  src="/docs/payments/first-invoice.png"
+  description="A draft invoice generated from unbilled time, with line items pulled from time entries and the Send button highlighted."
+/>
 
----
+## Pre-filled payment links
 
-## Ready for Day-One Operations?
+For quick collections that aren't a full invoice (consultation fees outside intake, donations, retainer top-ups), use a payment link:
 
-Use a day-one checklist to align account setup, compliance verification, payment readiness, and team responsibilities.
+```
+https://blawby.com/your-firm-slug?amount=12500
+```
 
-[Open the Day-One Checklist](/quick-start/day-one-checklist)
+The `amount` parameter is in cents. `12500` = $125.00. Generate the link from **Settings → Payments → Payment link**, then change the amount per request directly in the URL.
+
+## Common questions
+
+**The first checkpoint cleared but charges aren't enabled.**
+Stripe is reviewing documents. Open your Stripe dashboard from **Settings → Payments → View on Stripe** — Stripe will list anything still needed. The Blawby checkpoint clears automatically once Stripe approves.
+
+**My first payout hasn't landed.**
+Stripe's first payout for a new connected account commonly takes 7–14 days. Subsequent payouts follow Stripe's standard schedule (typically T+2 for cards, T+5 for ACH).
+
+**A client paid by ACH and the invoice is "Pending."**
+ACH settlement takes a few business days. The invoice flips to Paid when Stripe confirms — no action needed from you.
+
+**I want to refund a payment.**
+Open the invoice → **Refund**. Refunds use Stripe's refund API; the invoice records the refund and notifies the client.
+
+## Next: set up intake so payment-collection happens at the right point
+
+Your intake template can require payment before submission, or after engagement acceptance, or not at all. Configure it to match your practice's free vs. paid consult policy.
+
+[Continue to Set Up Client Intake](/features/set-up-client-intake)

--- a/src/data/docs/quick-start/accept-first-payment.mdx
+++ b/src/data/docs/quick-start/accept-first-payment.mdx
@@ -44,7 +44,7 @@ This page covers both checkpoints, plus how to send your first invoice from a ma
 
 <DocPlaceholder
   kind="video"
-  src="/docs/payments/stripe-connect.mp4"
+  src="/media/docs/payments/stripe-connect.mp4"
   description="60-second walkthrough of the two Stripe Connect checkpoints in Blawby — link bank, enable charges — followed by sending the first invoice."
 />
 
@@ -78,7 +78,7 @@ If charges stay pending, open the Stripe dashboard — Stripe will list any docu
 
 <DocPlaceholder
   kind="screenshot"
-  src="/docs/payments/stripe-checkpoints.png"
+  src="/media/docs/payments/stripe-checkpoints.png"
   description="Stripe checkpoint card in Settings → Payments — checkpoint 1 (Linked), checkpoint 2 (Charges enabled)."
 />
 
@@ -119,7 +119,7 @@ The simplest first-payment path: log a few minutes of time on a matter, then gen
 
 <DocPlaceholder
   kind="screenshot"
-  src="/docs/payments/first-invoice.png"
+  src="/media/docs/payments/first-invoice.png"
   description="A draft invoice generated from unbilled time, with line items pulled from time entries and the Send button highlighted."
 />
 

--- a/src/data/docs/quick-start/create-practice-account.mdx
+++ b/src/data/docs/quick-start/create-practice-account.mdx
@@ -42,7 +42,7 @@ This page explains what onboarding collects, in what order, and how to make the 
 
 <DocPlaceholder
   kind="video"
-  src="/docs/onboarding/conversational-setup.mp4"
+  src="/media/docs/onboarding/conversational-setup.mp4"
   description="60-second walkthrough of PracticeOnboardingPage — the AI asks for the firm name, slug, accent color, contact info, services, and team."
 />
 
@@ -106,7 +106,7 @@ A dashboard showing:
 
 <DocPlaceholder
   kind="screenshot"
-  src="/docs/onboarding/dashboard-after-setup.png"
+  src="/media/docs/onboarding/dashboard-after-setup.png"
   description="Dashboard after first-time onboarding — intake queue, summary cards, quick-action buttons, notification bell."
 />
 

--- a/src/data/docs/quick-start/create-practice-account.mdx
+++ b/src/data/docs/quick-start/create-practice-account.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Create Your Practice Account"
-desc: "Create your Blawby practice account, verify firm details, and prepare your team for intake and payment setup."
+title: "Create Your Practice — Conversational Onboarding"
+desc: "Set up your Blawby practice through the AI-guided onboarding chat: name, slug, accent color, services, jurisdiction, and your first team members."
 image: "https://imagedelivery.net/Frxyb2_d_vGyiaXhS5xqCg/527f8451-2748-4f04-ea0f-805a4214cd00/public"
 author: "Paul Chris Luke"
 authorImage: "/images/logo.png"
@@ -8,198 +8,136 @@ category: "quick-start"
 contentType: "guide"
 order: 10
 createdAt: "04/30/2026"
-updatedAt: "04/30/2026"
+updatedAt: "05/07/2026"
+lastVerified: "05/07/2026"
 tags:
   - Setup
-  - Configuration
-  - Account
+  - Onboarding
+  - Practice
 keywords:
-  - Create blawby account
-  - Law firm account setup
-  - Legal practice account
-  - Blawby sign up
+  - Create blawby practice
+  - Conversational onboarding law firm
+  - Practice slug accent color
+  - Law firm software onboarding
 difficulty: "beginner"
 prerequisites: []
-timeToComplete: "5 minutes"
-nextSteps: ["install-chat-widget"]
+timeToComplete: "10 minutes"
+nextSteps: ["accept-first-payment"]
 schemaType: "HowTo"
-faq: []
+faq:
+  - question: "What is a practice slug?"
+    answer: "It's the short identifier for your firm in Blawby — it appears in widget URLs and payment links (e.g. acme-law). Pick something short, lowercase, and memorable."
+  - question: "Can I change practice settings after onboarding?"
+    answer: "Yes. Everything in onboarding can be edited from Settings → Practice afterward, including slug, accent color, services, and jurisdiction coverage."
+  - question: "Do I need to connect Stripe before I can use the dashboard?"
+    answer: "No. You can complete onboarding and explore the dashboard without Stripe, but you'll need to connect it before you can collect payments. See Connect Stripe."
 noindex: false
 ---
 
-# Create Your Practice Account
+# Create Your Practice
 
-Creating a Blawby practice account unlocks 24/7 lead capture, reduces admin overhead, and helps your firm get paid faster. With a single account, you can automate intake, streamline payments, and keep your team organized from day one. This guide walks you through the quick setup process so you can start benefiting right away.
+Onboarding in Blawby happens **in chat**, not on a long form. The setup assistant asks the questions in order, validates your answers as you go, and shows a progress score so you can see what's left.
 
-## Before You Begin
+This page explains what onboarding collects, in what order, and how to make the right choices.
 
-You'll need:
+<DocPlaceholder
+  kind="video"
+  src="/docs/onboarding/conversational-setup.mp4"
+  description="60-second walkthrough of PracticeOnboardingPage — the AI asks for the firm name, slug, accent color, contact info, services, and team."
+/>
 
-- Your law firm's basic information
-- Business email address
-- Practice details (areas of practice, location)
-- Banking information for payments (optional during setup)
+## What you'll need
 
-## Step 1: Sign Up
+Before you start, have these on hand. The assistant will pause on any of them, but it's faster if they're ready:
 
-1. Go to [app.blawby.com/register](https://ai.blawby.com/register)
-2. Choose your account type:
-   - **Solo Practice**: For individual attorneys
-   - **Small Firm**: 2-10 attorneys
-   - **Growing Firm**: 11+ attorneys
+- Firm name and a one-line description.
+- Business email and phone for client communication.
+- Office address (used for jurisdiction defaults and for displaying on payment receipts).
+- Website URL (optional but recommended — used for branding).
+- A short list of practice areas you want to handle.
+- Email addresses for any team members you want to invite.
 
-3. Enter your basic information:
-   - Full name
-   - Email address
-   - Phone number
-   - Law firm name
+## What onboarding collects
 
-## Step 2: Verify Your Email
+The assistant walks through five blocks. Each can be revised later from **Settings → Practice**.
 
-Check your email for a verification link. Click the link to verify your account and continue setup.
+### 1. Basics
 
-## Step 3: Practice Information
+- **Practice name** — the firm's full legal or trade name.
+- **Slug** — your short identifier (e.g. `acme-law`). It shows up in your widget URL and payment links. Keep it short and lowercase.
+- **Accent color** — used for client-facing surfaces: the chat widget, payment pages, engagement letters. Match your brand.
 
-Complete your practice profile:
+### 2. Contact
 
-### Basic Details
+- **Business email** — where firm-wide notifications land.
+- **Business phone** — surfaced on payment receipts and in the widget if you choose to show it.
+- **Address** — your primary office. Used for the jurisdiction defaults the AI applies when intaking from clients in that state.
 
-### Contact Information
+### 3. Services
 
-Select your primary practice areas:
+A short list of the practice areas you handle (e.g. Personal Injury, Family Law, Estate Planning). Each service can have a description that the AI surfaces during intake — so a client asking "do you handle X?" gets a real answer, not a generic deflection.
 
-- Personal Injury
-- Family Law
-- Estate Planning
-- Business Law
-- Criminal Defense
-- Real Estate
-- Immigration
-- Other (specify)
+You don't have to be exhaustive on day one. Add more later as your firm's scope evolves.
 
-## Step 4: Configure Basic Settings
+### 4. Coverage areas
 
-### Time Zone
+The jurisdictions where you're admitted to practice. The AI uses these for routing logic — for example, declining intakes from states where you can't represent the client, or flagging pro-hac-vice cases for review.
 
-Set your local time zone for accurate scheduling and timestamps.
+### 5. Team
 
-### Business Hours
+Invite the other attorneys, paralegals, or admin staff who'll be using Blawby with you. Each invite specifies a role:
 
-Define your regular business hours for appointment scheduling:
+| Role | What they can do |
+|---|---|
+| **Admin** | Full practice access — settings, billing, team management, every matter. |
+| **Attorney** | Matters, clients, intake review, time entry, invoices. |
+| **Staff** | Matters they're assigned to, time entry, file uploads — no settings or billing controls. |
 
-- Monday - Friday: 9:00 AM - 5:00 PM
-- Saturday: Closed
-- Sunday: Closed
+Invites go out by email. Team members create their own credentials when they accept.
 
-### Communication Preferences
+## What you'll see when onboarding is done
 
-Choose how you want to receive notifications:
+A dashboard showing:
 
-- Email notifications
-- SMS alerts
-- In-app notifications only
+- Your **intake queue** (empty until your first widget submission).
+- **Recent matters**, **outstanding payments**, **new clients** — placeholder cards until you have data.
+- **Quick actions** — log a time entry, send a payment request, create a matter, view reports.
+- A persistent **bell** for in-app notifications.
 
-## Step 5: Payment Setup (Optional)
+<DocPlaceholder
+  kind="screenshot"
+  src="/docs/onboarding/dashboard-after-setup.png"
+  description="Dashboard after first-time onboarding — intake queue, summary cards, quick-action buttons, notification bell."
+/>
 
-You can skip this step and set up payments later, but completing it now allows you to accept payments immediately.
+## Common questions during onboarding
 
-### Connect Bank Account
+**My firm name is taken as a slug.**
+Slugs are unique across all of Blawby. Add a short qualifier (`acme-law-co`, `acme-pllc`).
 
-1. Click "Connect Bank Account"
-2. Enter your routing and account numbers
-3. Verify micro-deposits (1-2 business days)
+**Can I onboard before I'm ready to take clients?**
+Yes. Onboarding doesn't expose your widget publicly until you decide. You can configure intake templates, invite your team, and explore the dashboard before sharing your widget URL.
 
-### Configure Payment Methods
+**I'm a solo attorney. Do I still need to invite team members?**
+No. Skip the team step and move on. You can invite later as you grow.
 
-Enable payment types you want to accept:
+**I'm not sure what to put as my accent color.**
+The default works fine. You can change it any time from **Settings → Practice → Branding** and it'll update across all client-facing surfaces.
 
-- Credit/Debit Cards
-- Bank Transfers (ACH)
-- Payment Plans
+## Security defaults
 
-### IOLTA Trust Account
+Every Blawby practice ships with these on by default; you don't configure them:
 
-If you handle client funds:
+- All traffic over HTTPS.
+- Sessions issued and validated by Blawby's hosted Better Auth.
+- Encryption at rest for client records, files, and chat history.
+- File-upload validation (25 MB cap, MIME-type checks).
+- Rate limiting on AI and intake endpoints.
 
-- Set up your IOLTA trust account
-- Configure automatic transfers
-- Set compliance rules
+Two-factor authentication is optional and can be enabled per user under **Settings → Security**.
 
-## Step 6: Review and Confirm
+## Next: connect Stripe so you can collect payments
 
-Review your practice information:
+The dashboard works without Stripe, but you'll need it before your first invoice or consultation fee can be collected.
 
-- ✅ Personal details verified
-- ✅ Practice information complete
-- ✅ Contact information updated
-- ✅ Business hours set
-- ✅ Payment preferences configured
-
-Click "Complete Setup" to finish.
-
-## What's Next?
-
-Your practice account is now ready! Here's what we recommend doing next:
-
-1. **Install the Chat Widget** - Add AI chat to your website
-2. **Accept Your First Payment** - [Accept Your First Payment](/quick-start/accept-first-payment)
-3. **Set Up Client Intake** - [Set Up Client Intake](/features/set-up-client-intake)
-4. **Customize AI Chat** - [Customize AI Chat](/ai-chat/ai-chat-client-acquisition)
-
-## Account Dashboard Overview
-
-Once logged in, you'll see your main dashboard with:
-
-### Quick Actions
-
-- **Start New Conversation**: Begin a chat with a client
-- **Create Invoice**: Send a payment request
-- **Schedule Consultation**: Book client meetings
-- **View Analytics**: Check your practice metrics
-
-### Navigation Menu
-
-- **Conversations**: All client communications
-- **Payments**: Payment history and processing
-- **Clients**: Client management and records
-- **Settings**: Account and practice configuration
-- **Reports**: Analytics and insights
-
-## Security Features
-
-Your account includes built-in security:
-
-- **Two-Factor Authentication**: Optional extra security
-- **Data Encryption**: All data encrypted in transit and at rest
-- **Role-Based Access**: Control team member permissions
-- **Audit Logs**: Track all account activity
-
-## Getting Help
-
-If you need assistance during setup:
-
-- **Help Center**: [blawby.com/help](https://blawby.com/help)
-- **Live Chat**: Available 9 AM - 6 PM EST
-- **Email**: support@blawby.com
-
-## Common Setup Questions
-
-**Q: Can I change my practice type later?**
-A: Yes, you can update your practice type from Settings at any time.
-
-**Q: Is my banking information secure?**
-A: Your banking information is encrypted in transit and processed by PCI-compliant payment processors; see our [Privacy Policy](/privacy) and the [IOLTA Compliance Guide](/compliance/iolta-compliance) for details.
-
-**Q: Can I have multiple practice locations?**
-A: Yes, you can add multiple office locations in your practice settings.
-
-**Q: What if I need to add team members later?**
-A: You can invite team members from the Settings > Team section anytime.
-
----
-
-## Ready to Get Started?
-
-Your practice account is configured and ready to use. The next step is installing the chat widget to start capturing leads and engaging with clients 24/7.
-
-[Continue to Install Chat Widget](/ai-chat/install-chat-widget)
+[Continue to Accept Your First Payment](/quick-start/accept-first-payment)

--- a/src/data/docs/quick-start/day-one-checklist.mdx
+++ b/src/data/docs/quick-start/day-one-checklist.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Day-One Checklist for New Firms"
-desc: "A practical day-one checklist for law firms: account setup, compliance verification, payment readiness, and clear team ownership."
+title: "Day-One Checklist for New Firms in Blawby"
+desc: "A day-one checklist for firms launching on Blawby: practice setup, Stripe Connect, intake template, team roles, notifications, and a live dry run."
 image: "https://imagedelivery.net/Frxyb2_d_vGyiaXhS5xqCg/527f8451-2748-4f04-ea0f-805a4214cd00/public"
 author: "Paul Chris Luke"
 authorImage: "/images/logo.png"
@@ -8,123 +8,153 @@ category: "quick-start"
 contentType: "guide"
 order: 40
 createdAt: "04/30/2026"
-updatedAt: "04/30/2026"
+updatedAt: "05/07/2026"
+lastVerified: "05/07/2026"
 tags:
   - Quick-Start
   - Operations
   - Compliance
+  - Launch-Checklist
 keywords:
-  - Law firm onboarding checklist
-  - Blawby day one setup
-  - Legal operations launch checklist
-  - Trust and payment readiness
+  - Blawby day one checklist
+  - Law firm launch checklist
+  - Legal operations Blawby setup
+  - Trust readiness checklist
 difficulty: "beginner"
 prerequisites: ["create-practice-account"]
 timeToComplete: "30 minutes"
 nextSteps: ["accept-first-payment"]
 schemaType: "HowTo"
 faq:
-  - Question: "Who should own this checklist in a law firm?"
-    answer: "Usually an office manager, billing lead, or paralegal who can coordinate setup across attorneys and staff."
-  - Question: "Can solo attorneys use this checklist?"
-    answer: "Yes. Solo attorneys can use the same checklist and simply assign each item to themselves."
+  - question: "Who should own this checklist?"
+    answer: "Usually an office manager, billing lead, or paralegal who can coordinate setup across attorneys and staff. Solo attorneys can run through it themselves in about 30 minutes."
+  - question: "Can we go live without finishing the checklist?"
+    answer: "Yes, but several items (trust routing, notification policy, dry run) catch the kind of issue that's much more expensive to fix after a real client has hit it."
 noindex: false
 ---
 
 # Day-One Checklist for New Firms
 
-If your team is new to Blawby, this checklist helps you avoid the most common early mistakes: unclear ownership, incomplete verification, and payment workflows that break on first use.
+This is the launch playbook for a firm that's just signed up. Run through it once, document your decisions, and you'll skip the most common first-week issues — unclear ownership, fee/trust confusion, intake template gaps, and notification routing failures.
 
-Use this once, document your decisions, and keep it as your launch playbook.
+## 1. Assign ownership
 
-## 1) Assign Operational Ownership
+Before changing settings, decide who owns each area. Write it down somewhere you can find it later.
 
-Before changing any settings, decide who owns each area:
+- **Practice admin** — settings, team, integrations.
+- **Billing lead** — invoices, retainers, follow-up on unpaid balances, refunds.
+- **Trust / compliance** — trust-routing config, monthly reconciliation.
+- **Intake owner** — first response on new submissions, accept/decline decisions.
 
-- Account admin
-- Billing and invoice setup
-- Trust/compliance oversight
-- Intake follow-up ownership
+Why this matters: when ownership is unclear, items get done twice or not at all.
 
-Why this matters: when ownership is unclear, tasks get done twice or not at all.
+## 2. Verify your practice profile
 
-## 2) Complete Account and Identity Verification
+In **Settings → Practice**, confirm:
 
-Confirm your team has completed:
+- Practice name and slug.
+- Accent color matches your brand (it appears on widget, payment pages, and engagement letters).
+- Business email and phone.
+- Office address — used for jurisdiction defaults.
+- Services list — even if minimal, the AI uses this in intake.
+- Coverage areas — the jurisdictions you're admitted in.
 
-- Practice account setup
-- Business details and representative details
-- Required verification documents
+Why this matters: every client-facing surface (widget, payment receipt, engagement letter) reads from these fields.
 
-Why this matters: incomplete verification can delay payouts and interrupt onboarding.
+## 3. Clear both Stripe Connect checkpoints
 
-## 3) Confirm Payment Readiness
+In **Settings → Payments**:
 
-Validate your payment foundation:
+- ☐ Checkpoint 1 — bank linked through Stripe.
+- ☐ Checkpoint 2 — charges enabled.
 
-- Bank account connected and verified
-- Card and/or ACH enabled
-- Payment notifications going to the right person
-- First invoice flow reviewed
+If charges are still pending, open the Stripe dashboard from the Blawby link — Stripe will list any docs it still needs.
 
-Why this matters: this is the minimum required to collect funds without manual rescue work.
+[Read Accept Your First Payment](/quick-start/accept-first-payment) for the full Stripe Connect walkthrough.
 
-## 4) Confirm Trust and Compliance Routing
+## 4. Configure trust vs. operating routing (if you hold client funds)
 
-If you hold unearned client funds:
+If your firm will ever hold unearned funds (retainers, settlement deposits, court filing-fee deposits):
 
-- Trust account is configured correctly
-- Team understands trust vs operating movement rules
-- Reconciliation owner is assigned
+- ☐ Trust routing configured in **Settings → Payments → Trust routing**.
+- ☐ Operating-account card linked for processing fees.
+- ☐ Trust/compliance owner identified (see step 1).
 
-Why this matters: trust errors are preventable and expensive. Clear setup protects both clients and your firm.
+If you don't hold client funds, skip this — all payments will land in your operating account.
 
-## 5) Set Intake-to-Payment Workflow
+## 5. Build your first intake template
 
-Define your standard operating flow:
+In **Settings → Intake templates**:
 
-1. New inquiry arrives
-2. Matter is qualified
-3. Consultation/payment request is sent
-4. Payment status is tracked
-5. Consultation proceeds or follow-up is triggered
+- ☐ Template created with a recognizable slug (e.g. `personal-injury`).
+- ☐ Required fields kept short — contact, matter type, case summary, jurisdiction, urgency.
+- ☐ A few enrichment fields configured for the post-submit "strengthen your case" phase.
+- ☐ Conditional fields where they apply (e.g. "court date" only if "open case" = yes).
+- ☐ Consultation fee toggle set correctly for your free-vs-paid policy.
 
-Why this matters: firms that define this flow early convert more inquiries into paying matters.
+[Read Intake Templates](/features/intake-templates) for the field model.
 
-## 6) Document Your First-Week Team Rules
+## 6. Invite your team and set roles
 
-Write down:
+In **Settings → Team**:
 
-- Required response time for new inquiries
-- Who follows up on unpaid invoices
-- What happens after failed payment attempts
-- When to escalate chargebacks or disputes
+- ☐ Each team member invited with the right role (Admin / Attorney / Staff).
+- ☐ At least one Admin besides yourself, so you're not a single point of failure.
+- ☐ Default matter assignees agreed on (who picks up new accepted intakes?).
 
-Why this matters: written rules prevent inconsistent client communication.
+## 7. Set notification policy
 
-## 7) Run a Live Dry Run
+In **Settings → Notifications**:
 
-Do one internal simulation:
+- ☐ In-app notifications on for every team member.
+- ☐ Email notifications enabled at least for: new intake, invoice paid, engagement signed.
+- ☐ Push notifications (OneSignal) enabled if you want mobile/web alerts.
+- ☐ Backup person identified for the intake owner — for vacation and after-hours coverage.
 
-- Create a sample client
-- Send an invoice or payment link
-- Confirm payment notifications
-- Verify payout visibility
-- Confirm everyone knows their role
+Why this matters: a fast first response on a new intake is the #1 conversion driver. Make sure the notification reaches a human.
 
-Why this matters: dry runs catch process issues before they affect real clients.
+## 8. Run a live dry run
 
-## Success Criteria
+Before sharing your widget URL externally:
 
-You are ready for live operations when:
+- ☐ Open your widget URL from a private browser window.
+- ☐ Submit a test intake with realistic answers.
+- ☐ Confirm the intake reaches your queue with all expected fields.
+- ☐ Confirm the right person got the notification (in-app, email, or push).
+- ☐ Accept the test intake; confirm a matter is created.
+- ☐ Send a $1 test invoice to yourself, pay it with a Stripe test card, confirm the invoice flips to Paid.
 
-- A client can pay successfully
-- Your team can see payment status clearly
-- Trust-routing responsibility is documented
-- Failed-payment ownership is explicit
+Document anything confusing during the test — those are the issues real clients will hit first.
 
-## Next Step
+## 9. Document your firm rules
 
-After day-one setup, use the SOP below so your team handles payment failures and disputes consistently.
+Write the playbook your team will follow. The minimum:
+
+- Required response time for new intakes (e.g. same business day).
+- Who follows up on unpaid invoices, and when.
+- What happens after a failed payment — see [Failed Payment & Chargeback SOP](/features/failed-payment-and-chargeback-sop).
+- When a matter escalates from staff to attorney.
+
+## 10. Go live
+
+When the dry run passes:
+
+- Add the widget script to your firm website. See [Install the Chat Widget](/ai-chat/install-chat-widget).
+- Share the widget URL in email signatures and intake replies.
+- Watch the first week of submissions closely; expect to refine intake template fields once you've seen real answers.
+
+## Success criteria
+
+You're ready when:
+
+- A real client can complete intake and reach your queue.
+- Your team can see the submission and the right person gets notified.
+- A test invoice can be sent and paid.
+- Trust-routing responsibility is documented (or explicitly N/A).
+- Failed-payment ownership is explicit.
+
+## Next: pair this with the failed-payment SOP
+
+Once you're live, the most common operational hiccup is a failed card charge or chargeback. Make sure your team has a written response.
 
 [Open Failed Payment & Chargeback SOP](/features/failed-payment-and-chargeback-sop)

--- a/src/data/docs/reference/api-reference.mdx
+++ b/src/data/docs/reference/api-reference.mdx
@@ -1,7 +1,6 @@
 ---
-title: "Blawby API Reference | Technical Documentation"
-metaTitle: "API Reference — Blawby"
-desc: "Explore the Blawby API reference for technical specs on payments and intake. Secure integration for legal tech."
+title: "Blawby Developer Reference"
+desc: "What ships today for developers integrating with Blawby — embeddable widget, payment links, notifications — plus the public API and webhook roadmap."
 image: "https://imagedelivery.net/Frxyb2_d_vGyiaXhS5xqCg/527f8451-2748-4f04-ea0f-805a4214cd00/public"
 author: "Paul Chris Luke"
 authorImage: "/images/logo.png"
@@ -9,403 +8,137 @@ category: "reference"
 contentType: "reference"
 order: 10
 createdAt: "02/15/2024"
-updatedAt: "02/15/2024"
+updatedAt: "05/07/2026"
+lastVerified: "05/07/2026"
 tags:
-  - Api
-  - Webhooks
-  - Authentication
-  - Endpoints
-  - Sdk
+  - Developer
   - Integration
-keywords:
-  - Blawby api
-  - Blawby api documentation
+  - Widget
   - Webhooks
-  - Authentication
-  - Endpoints reference
-  - Developer integration guide
-  - Sdk reference
-summary: "Complete reference documentation for Blawby API endpoints, authentication, webhooks, and SDK usage. Technical specifications for developers."
+keywords:
+  - Blawby developer reference
+  - Blawby widget integration
+  - Legal intake widget embed
+  - Blawby webhooks
+  - Blawby public API
+summary: "Practical reference for the integration surfaces Blawby exposes today, plus a roadmap for the public API."
 schemaType: "TechArticle"
 faq:
-  - question: "What authentication methods does Blawby support?"
-    answer: "Blawby supports API key authentication, OAuth 2.0, and session-based authentication for different integration scenarios."
-  - question: "How do I handle API rate limits?"
-    answer: "Implement exponential backoff with jitter, monitor response headers for rate limit indicators, and provide user-friendly error messages."
-  - question: "What are the best practices for webhook security?"
-    answer: "Always verify webhook signatures using HMAC-SHA256, store secrets securely, use HTTPS endpoints, and implement idempotency keys for reliable event processing."
+  - question: "Does Blawby have a public REST API?"
+    answer: "Not yet. The platform exposes a publicly embeddable chat widget today and is working toward a documented public API. Integrations that need programmatic access can join the early-access list."
+  - question: "How do I install the chat widget on my website?"
+    answer: "Copy the embed snippet from your dashboard's widget settings. It loads the Blawby intake widget on any page where the script is included."
+  - question: "Are there webhooks I can subscribe to?"
+    answer: "Server-to-server webhooks are part of the public API roadmap. Today, Blawby pushes notifications to your team via in-app, email, and OneSignal push channels."
 noindex: false
 ---
 
-# Blawby API Reference
+# Blawby Developer Reference
 
-Complete technical documentation for integrating with the Blawby platform. This reference covers all available endpoints, authentication methods, webhook events, and best practices for secure API development.
+This page is the honest map of what's available to developers integrating with Blawby today, and what's on the roadmap.
 
-> This page is for developers integrating with Blawby's API.
-> If you're a lawyer or legal staff, you don't need this -
-> [start here instead](/guides/get-started).
+> **About this page** — Blawby's product is a hosted application for law firms. The integration surfaces below are what's stable enough to build against right now. The full public REST API is still being designed; sign up for early access at the bottom of this page if you need it.
 
-## Authentication
+## What's available today
 
-### API Key Authentication
+### 1. Embeddable chat widget
 
-The most straightforward method for server-to-server communication.
+The chat widget is the primary integration surface. Drop a script tag on your law firm's website and the widget renders the live intake experience: AI-guided conversation, file uploads, optional consultation fee collection, and submission into your firm's queue.
 
-#### Endpoint
+See [Install the Chat Widget](/ai-chat/install-chat-widget) for setup.
 
-```
-POST /api/v1/authenticate
-```
+What the widget supports:
 
-#### Request Body
+- AI-guided intake in **18 languages** with full RTL for Arabic.
+- File attachments up to **25 MB** per file (images, video, audio, PDF, Word docs).
+- Optional **consultation fee** collection via Stripe before submission.
+- **Conditional intake fields** (the AI only asks follow-up questions when a parent answer matches).
+- **Cross-origin cookie handling** — the widget is designed to work when embedded on your firm's domain, not Blawby's.
 
-```json
-{
-  "apiKey": "your-api-key",
-  "practiceId": "your-practice-id"
-}
-```
+### 2. Pre-filled payment links
 
-#### Response
-
-```json
-{
-  "token": "jwt_token_here",
-  "expiresIn": 3600,
-  "practiceId": "your-practice-id",
-  "permissions": ["read", "write", "admin"]
-}
-```
-
-### Session-Based Authentication
-
-For client applications that maintain user sessions.
-
-#### Endpoint
+Generate a payment link in the dashboard, then customize the amount per request via a URL parameter. This works in email, SMS, intake email replies — anywhere a link works.
 
 ```
-POST /api/v1/auth/session
+https://blawby.com/your-firm-slug?amount=12500
 ```
 
-#### Request Body
+The `amount` parameter is in cents. `12500` = $125.00. See [Accepting Payments](/payments/accepting-payments) for the full link reference.
 
-```json
-{
-  "token": "jwt_token_here",
-  "practiceId": "your-practice-id"
-}
-```
+### 3. Notification channels
 
-#### Response
+When something happens in your firm (intake submitted, invoice paid, engagement signed, matter status changed) Blawby fans out notifications across:
 
-```json
-{
-  "sessionId": "session_abc123",
-  "expiresIn": 1800,
-  "user": {
-    "id": "user_456",
-    "email": "user@example.com",
-    "name": "John Doe"
-  }
-}
-```
+- **In-app** — bell icon in the dashboard.
+- **Email** — transactional, branded with your firm.
+- **Push** — via OneSignal SDK on the web client.
 
-## Core API Endpoints
+You don't subscribe to these as a developer today; they're delivered to your team's accounts. Server-to-server webhook delivery is on the roadmap (see below).
 
-### Client Management
+### 4. Paralegal document analysis (in-product)
 
-#### Get Client
+When clients upload documents into chat, an AI paralegal streams analysis status messages and surfaces extracted facts, deadlines, and risks. This is currently surfaced inside the Blawby app — the underlying analysis WebSocket is **not yet a public integration point**.
 
-```
-GET /api/v1/clients/{id}
-```
+## What's on the roadmap
 
-#### Response
+These are the integration capabilities being designed but not yet released for public use:
 
-```json
-{
-  "id": "client_456",
-  "name": "John Doe",
-  "email": "john@example.com",
-  "phone": "+1-555-0123",
-  "status": "active",
-  "createdAt": "2024-01-15T00:00:00Z",
-  "updatedAt": "2024-01-20T10:30:00Z"
-}
-```
+- **Public REST API** — programmatic CRUD for matters, invoices, contacts, intakes, and time entries.
+- **Webhooks** — subscribe to events like `intake.submitted`, `intake.accepted`, `engagement.signed`, `invoice.paid`, `payout.created`. HMAC-signed, with idempotency keys.
+- **OAuth 2.0 for third-party apps** — let other tools connect to a Blawby practice on behalf of a user.
+- **SDK packages** — `@blawby/sdk` for JS/TS and a Python equivalent. None are published today.
+- **Granular role-based API tokens** — scoped tokens (e.g., `intake.read`, `invoices.write`) for service integrations.
 
-#### Create Client
+<DocPlaceholder
+  kind="diagram"
+  src="/docs/reference/api-surface-diagram.svg"
+  description="Future API surface — embeddable widget on the left, public REST API in the middle, your service on the right."
+/>
 
-```
-POST /api/v1/clients
-```
+## Authentication today
 
-#### Request Body
+End-user authentication is handled by Blawby's hosted Better Auth deployment. Sessions are issued as cookies and validated server-side; there is **no public API key issuance yet**.
 
-```json
-{
-  "name": "Jane Smith",
-  "email": "jane@example.com",
-  "phone": "+1-555-0124",
-  "status": "active"
-}
-```
+If you need session-aware behavior in your own service while we work toward an API:
 
-#### Response
+- Mount the chat widget on a page your authenticated user is already on.
+- Pass a stable practice slug or organization identifier in the embed snippet so the widget routes to the right firm.
+- Treat any data the widget posts back to *your* domain (e.g., a thank-you page) as untrusted user input — Blawby is the source of truth.
 
-```json
-{
-  "id": "client_457",
-  "name": "Jane Smith",
-  "email": "jane@example.com",
-  "phone": "+1-555-0124",
-  "status": "active",
-  "createdAt": "2024-01-15T14:20:00Z",
-  "updatedAt": "2024-01-15T14:20:00Z"
-}
-```
+## Security expectations for the future API
 
-#### Update Client
+When the public API ships, integrations should plan for these baseline behaviors. Building against these expectations now will save migration work later:
 
-```
-PUT /api/v1/clients/{id}
-```
+- **HTTPS only.** No plaintext.
+- **Webhook verification** with HMAC-SHA256 over the raw request body. Compare with `crypto.timingSafeEqual` (Node) or constant-time equivalents.
+- **Idempotency keys** on any state-changing call so retries don't duplicate writes.
+- **Exponential backoff with jitter** on rate-limit responses.
+- **Never embed credentials in client-side code.** Calls must originate from a server you control.
 
-#### Request Body
-
-```json
-{
-  "name": "John Doe Updated",
-  "email": "john.updated@example.com",
-  "status": "active"
-}
-```
-
-### Payments
-
-#### Create Invoice
-
-```
-POST /api/v1/invoices
-```
-
-#### Request Body
-
-```json
-{
-  "clientId": "client_456",
-  "amount": 25000,
-  "currency": "USD",
-  "dueDate": "2024-02-15",
-  "description": "Legal consultation services"
-}
-```
-
-#### Response
-
-```json
-{
-  "id": "inv_123",
-  "status": "draft",
-  "createdAt": "2024-01-10T15:30:00Z"
-}
-```
-
-#### Process Payment
-
-```
-POST /api/v1/payments
-```
-
-#### Request Body
-
-```json
-{
-  "invoiceId": "inv_123",
-  "amount": 25000,
-  "paymentMethod": "card",
-  "currency": "USD"
-}
-```
-
-#### Response
-
-```json
-{
-  "id": "pay_456",
-  "status": "succeeded",
-  "createdAt": "2024-01-10T16:45:00Z"
-}
-```
-
-### Webhooks
-
-### Supported Events
-
-#### Payment Events
-
-- `payment.succeeded` - Payment completed successfully
-- `payment.failed` - Payment failed
-- `payment.requires_action` - Payment requires additional action
-
-#### Invoice Events
-
-- `invoice.sent` - Invoice sent to client
-- `invoice.paid` - Invoice marked as paid
-- `invoice.overdue` - Invoice is overdue
-
-#### Webhook Configuration
-
-#### Endpoint
-
-```
-POST /api/v1/webhooks
-```
-
-#### Request Headers
-
-```json
-{
-  "Content-Type": "application/json",
-  "x-blawby-signature": "computed_hmac_signature"
-}
-```
-
-#### Request Body
-
-```json
-{
-  "url": "https://your-domain.com/webhooks",
-  "events": ["payment.succeeded", "invoice.sent"],
-  "secret": "your_webhook_secret"
-}
-```
-
-#### Verification Process
-
-1. Extract signature from `x-blawby-signature` header
-2. Extract timestamp from `x-blawby-timestamp` header
-3. Extract event payload from request body
-4. Compute expected HMAC using your webhook secret
-5. Compare computed signature with received signature
+A representative HMAC verification — pattern only, the real signing scheme will be published with the API:
 
 ```javascript
-function verifyWebhookSignature(payload, signature, secret) {
-  const crypto = require("crypto");
-  const expectedSignature = crypto
+import crypto from "node:crypto";
+
+function verifyWebhookSignature(rawBody, signature, secret) {
+  const expected = crypto
     .createHmac("sha256", secret)
-    .update(JSON.stringify(payload), "utf8")
+    .update(rawBody, "utf8")
     .digest("hex");
-
-  return signature === expectedSignature;
+  return crypto.timingSafeEqual(
+    Buffer.from(expected, "hex"),
+    Buffer.from(signature, "hex"),
+  );
 }
 ```
 
-## SDK Integration
+## Get early access
 
-### JavaScript/TypeScript
+If your team needs the public API or webhooks now, [contact developer support](https://ai.blawby.com/contact). Priority is given to firms with a concrete integration use case (CRM sync, accounting, document management).
 
-```javascript
-import { BlawbyClient } from "@blawby/sdk";
+## Related guides
 
-const client = new BlawbyClient({
-  apiKey: process.env.BLAWBY_API_KEY,
-  practiceId: process.env.PRACTICE_ID,
-  baseUrl: "https://api.blawby.com",
-});
-```
-
-### Python
-
-```text
-import requests
-import hmac
-import hashlib
-import json
-
-class BlawbyClient:
-    def __init__(self, api_key, practice_id, base_url):
-        self.api_key = api_key
-        self.practice_id = practice_id
-        self.base_url = base_url
-        self.session = requests.Session()
-
-    def authenticate(self):
-        response = self.session.post(f"{self.base_url}/api/v1/authenticate", json={
-            "apiKey": self.api_key,
-            "practiceId": self.practice_id
-        })
-        return response.json()
-
-    def create_invoice(self, client_id, amount, description):
-        return self.session.post(f"{self.base_url}/api/v1/invoices", json={
-            "clientId": client_id,
-            "amount": amount,
-            "currency": "USD",
-            "description": description
-        })
-```
-
-## Rate Limits
-
-- **Authentication**: 100 requests per minute
-- **API Calls**: 1000 requests per minute per practice
-- **Webhooks**: 10 events per minute per webhook
-
-## Error Handling
-
-### Standard Response Format
-
-```json
-{
-  "error": {
-    "code": "RATE_LIMIT_EXCEEDED",
-    "message": "Rate limit exceeded. Please try again later.",
-    "details": {
-      "retryAfter": 60,
-      "limit": 1000,
-      "current": 950
-    }
-  }
-}
-```
-
-### HTTP Status Codes
-
-- `200` - Success
-- `400` - Bad Request
-- `401` - Unauthorized
-- `429` - Rate Limited
-- `500` - Server Error
-
-## Best Practices
-
-### Security
-
-- Never expose API keys in client-side code
-- Use HTTPS for all API calls
-- Validate all input data
-- Implement proper webhook signature verification
-- Use environment variables for sensitive configuration
-
-### Performance
-
-- Implement request queuing for rate limit handling
-- Use connection pooling for high-volume applications
-- Cache frequently accessed data
-- Monitor API response times and optimize accordingly
-
-## Testing
-
-### Test Environment
-
-- Use `https://api-staging.blawby.com` for development
-- Test webhook delivery using tools like ngrok or webhook.site
-- Validate all error scenarios and edge cases
-
-This reference documentation provides comprehensive technical specifications for secure and efficient Blawby API integration.
-
-
----
-
-Ready to integrate Blawby into your practice? [Contact our developer support team](https://ai.blawby.com/contact) to get started.
+- [Install the Chat Widget](/ai-chat/install-chat-widget) — embed instructions for builders and developers.
+- [Set Up Client Intake](/features/set-up-client-intake) — configure what the widget collects.
+- [Accepting Payments](/payments/accepting-payments) — pre-filled payment links and fee routing.
+- [IOLTA Compliance Guide](/compliance/iolta-compliance) — how Blawby separates trust and operating funds.

--- a/src/data/docs/reference/api-reference.mdx
+++ b/src/data/docs/reference/api-reference.mdx
@@ -91,7 +91,7 @@ These are the integration capabilities being designed but not yet released for p
 
 <DocPlaceholder
   kind="diagram"
-  src="/docs/reference/api-surface-diagram.svg"
+  src="/media/docs/reference/api-surface-diagram.svg"
   description="Future API surface — embeddable widget on the left, public REST API in the middle, your service on the right."
 />
 

--- a/src/data/lessons/accepting-payments.mdx
+++ b/src/data/lessons/accepting-payments.mdx
@@ -9,7 +9,8 @@ category: "payments"
 contentType: "lesson"
 order: 20
 createdAt: "01/01/2024"
-updatedAt: "01/01/2024"
+updatedAt: "05/07/2026"
+lastVerified: "05/07/2026"
 tags:
   - Payments
   - Billing
@@ -92,19 +93,19 @@ This keeps payment requests simple and consistent across email, text, and intake
 
 ---
 
-## Compliance and Admin Support
+## Compliance and trust routing
 
-{/* TODO: Legal/Product to verify exact compliance capabilities and fund-routing automation. */}
+Blawby's payment model is structured for trust compliance:
 
-Blawby is designed to support compliance and reduce friction for law offices of any size:
+- **Trust-eligible payments route in full to your trust account.** Blawby never deducts fees from trust dollars.
+- **Processing and platform fees** are charged separately to a card linked to your operating account.
+- **Audit trail** — every transaction logs to the matter's Activity tab with timestamp, amount, and the user who performed the change.
 
-- **Assistance with separation of earned and unearned funds:** Tools to help route payments to designated accounts and keep fees separate.
-- **No fees deducted from trust:** Processing and platform fees are billed to your operating account, assisting with trust fund integrity.
-- **Clear, searchable audit trails:** Every transaction is logged and easy to review, making reconciliations faster.
+Configure trust routing in **Settings → Payments → Trust routing** before collecting any retainer or trust-eligible deposit.
 
 [Read about IOLTA compliance](/compliance/iolta-compliance)
 
-**Note:** Always consult with your accountant to ensure proper handling of client funds, especially regarding trust accounts.
+**Note:** Always consult with your accountant or trust-account compliance counsel for jurisdiction-specific handling of client funds.
 
 ---
 

--- a/src/data/lessons/invoicing.mdx
+++ b/src/data/lessons/invoicing.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Legal Invoicing: Automate Billing & Get Paid Faster"
+title: "Legal Invoicing — Generate from Matter, Get Paid"
 metaTitle: "Legal Invoicing for Law Firms | Blawby"
-desc: "Create, send, and track legal invoices in Blawby so your firm can collect payments faster with clearer billing records."
+desc: "Generate invoices in Blawby from a matter's unbilled time and expenses, send a Stripe-hosted pay link, and track Draft/Sent/Paid status by matter."
 image: "https://imagedelivery.net/Frxyb2_d_vGyiaXhS5xqCg/527f8451-2748-4f04-ea0f-805a4214cd00/public"
 author: "Paul Chris Luke"
 authorImage: "/images/logo.png"
@@ -9,88 +9,138 @@ category: "payments"
 contentType: "lesson"
 order: 40
 createdAt: "01/01/2024"
-updatedAt: "01/01/2024"
+updatedAt: "05/07/2026"
+lastVerified: "05/07/2026"
 tags:
   - Invoicing
   - Billing
-  - Invoices
+  - Matters
+  - Stripe
 keywords:
   - Law firm invoicing
-  - Legal invoice software
-  - Client invoice payments
-  - Blawby invoicing
+  - Generate invoice from time entries
   - Legal billing workflow
+  - Stripe-hosted invoice payment
+  - Retainer draw invoice
 targetAudience: "practice-owners"
 searchIntent: "informational"
 primaryKeyword: "law firm invoicing"
-secondaryKeywords: ["legal billing", "client invoices", "automated invoicing"]
-summary: "Use Blawby invoicing to send clear bills, collect payments, and track invoice status by client."
+secondaryKeywords: ["legal billing", "matter billing", "retainer invoice"]
+summary: "Generate invoices from a matter's unbilled summary, edit line items, send a Stripe-hosted pay link, and track status."
 schemaType: "Article"
 faq:
-  - question: "Can I invoice clients who haven’t paid before?"
-    answer: "Yes. You can create and send invoices to both new and existing clients directly from the Clients section in your dashboard."
-  - question: "Do invoices include my law firm’s branding?"
-    answer: "Yes. Invoices automatically include your firm's logo, contact info, and payment terms. You can customize this information under your account settings."
-  - question: "Can I accept payments directly from the invoice?"
-    answer: "Yes. Clients receive a secure link with the invoice that lets them pay online via credit card or ACH."
-  - question: "What if I need to collect payment immediately?"
-    answer: "Use a Payment Link instead of an invoice. Invoices require a due date of at least one day in the future."
-  - question: "Will I be notified when a client pays an invoice?"
-    answer: "Yes. You’ll receive an email notification when a payment is completed, and it will also appear in your dashboard in real time."
+  - question: "Where do I create an invoice?"
+    answer: "From the matter's Billing tab. Blawby pulls unbilled time and expenses into line items; you edit, add a flat-fee or retainer line if needed, and send."
+  - question: "How does the client pay?"
+    answer: "They get an email with a Stripe-hosted pay link. They can pay by card or ACH without creating a Blawby account."
+  - question: "When does the invoice flip to Paid?"
+    answer: "Automatically when payment clears. For ACH, that's when Stripe confirms settlement (a few business days). The matter's Activity tab logs every status change."
 noindex: false
 ---
 
 # Invoicing with Blawby
 
-Blawby makes it easy for law firms to create, send, and manage professional invoices for their clients.
+Invoices in Blawby are generated **from a matter**. The matter's unbilled summary (logged time, expenses, flat-fee line items, retainer draws) rolls into an invoice in one click. The client pays through a Stripe-hosted link; the invoice flips to Paid automatically when payment clears.
 
-To manage your invoices, visit [Invoicing](https://ai.blawby.com/invoicing).
+This page covers the operational flow. For the broader matter context — billing types, retainer balances, the seven matter tabs — see [Matters Overview](/features/matters-overview).
 
-## Overview
+## Generate an invoice
 
-Streamline your billing process with Blawby's powerful invoicing features designed for legal professionals.
+1. **Open the matter.** Most invoices come from active matters; you can also generate one from the Matters list view.
+2. **Switch to the Billing tab.** The **unbilled summary** card shows your billable hours, unbilled expenses, and any flat-fee or retainer items waiting to be invoiced.
+3. **Click Generate invoice.** The line items pull from the unbilled summary automatically.
+4. **Edit if needed.** Adjust descriptions, remove items you're not billing yet, or add a flat-fee or retainer-draw line.
+5. **Set the due date.** Defaults to your firm's invoice terms; can be changed per invoice.
+6. **Preview, then Send.** The client gets an email with a Stripe-hosted pay link.
 
-**Note:** All invoices must have a due date set for at least the next day. If you need to collect a payment immediately (same-day), use a [Payment Link](/payments/accepting-payments) instead. Payment links allow clients to pay you instantly, without waiting for an invoice due date.
+<DocPlaceholder
+  kind="screenshot"
+  src="/docs/billing/generate-invoice.png"
+  description="Billing tab on a matter — unbilled summary expanded, Generate invoice CTA highlighted, draft preview to the right."
+/>
 
-## Creating Invoices
+## What the client sees
 
-Use the following steps to create and send an invoice with Blawby:
+The email contains a clear summary, the line items, the total, and a **Pay** button:
 
-1. **Navigate to Clients and Select a Client.** (1 minute) Go to the "Clients" section in your Blawby dashboard and select the client you want to invoice. If you need to add or edit client information, see [Managing Clients](/payments/clients).
-2. **Click Generate Invoice.** (1 minute) In the client's profile, click "Generate Invoice." The invoice template will automatically use your firm's branding, including logo and contact information. If you need to update your contact info or logo, see [Getting Started](/guides/get-started).
-3. **Add Line Items for Legal Services.** (2 minutes) Enter a description of the service, time spent (if billing hourly), rate, and any flat fees as applicable. You can add multiple line items to reflect the full scope of work.
-4. **Set the Due Date.** (1 minute) Choose a due date for the invoice. Note: All invoices must have a due date set for at least the next day. If you need to collect a payment immediately, use a [Payment Link](/payments/accepting-payments) instead.
-5. **Preview the Invoice.** (1 minute) Review all details to ensure accuracy before sending.
-6. **Send the Invoice.** (1 minute) Click "Send" to email the invoice to your client. The client will receive a secure link to pay online.
+- They click **Pay**.
+- Stripe's hosted checkout collects card or ACH details.
+- They pay; the invoice flips to **Paid** in your dashboard automatically.
+- Both sides get a confirmation email with receipt.
 
-For more information on payment options, visit [Payments](/payments/accepting-payments).
+For ACH payments, the invoice shows **Pending** until Stripe confirms settlement (a few business days). No action needed on your side.
 
-## After Creating an Invoice
+## Invoice types Blawby supports
 
-Once you have created and sent an invoice, an email is automatically sent to your client requesting payment. This email includes a link that directs them to the payment page, where they can choose from various payment options. For more information on payment options, visit [Payments](/payments/accepting-payments).
+Each line item on an invoice can be:
 
-## Payment Confirmation
+- **Time entry** — hourly billing pulled from the matter's logged time. Rate applies per user role (attorney vs. admin).
+- **Expense** — flat amounts logged on the matter (filing fees, court costs, etc.).
+- **Flat fee** — for engagement work priced as a fixed amount.
+- **Retainer draw** — bills against the matter's retainer balance. If the balance is short, the client pays the difference.
 
-After a payment is successfully processed, both you and your client will receive a payment confirmation email. This ensures that both parties have a record of the transaction, providing peace of mind and a clear audit trail.
+A single invoice can mix types — common pattern: hourly time entries plus a flat-fee filing line plus an expense reimbursement, all on one invoice.
 
-## Frequently Asked Questions
+## Status lifecycle
 
-### Can I invoice clients who haven’t paid before?
+```
+Draft → Sent → (Pending) → Paid
+                  ↓
+               Overdue
+```
 
-Yes. You can create and send invoices to both new and existing clients directly from the Clients section in your dashboard.
+- **Draft** — generated but not sent. Edit freely.
+- **Sent** — email is out, client has the pay link.
+- **Pending** — for ACH; payment initiated, awaiting Stripe settlement.
+- **Paid** — payment cleared. Time entries flagged "billed."
+- **Overdue** — past due date and not paid. Reminder logic kicks in (configurable).
 
-### Do invoices include my law firm’s branding?
+Status changes log to the matter's Activity tab automatically.
 
-Yes. Invoices automatically include your firm's logo, contact info, and payment terms. You can customize this information under your account settings.
+## Retainer-draw invoices
 
-### Can I accept payments directly from the invoice?
+For retainer matters, the invoicing flow draws from the retainer balance:
 
-Yes. Clients receive a secure link with the invoice that lets them pay online via credit card or ACH.
+1. Generate the invoice from the unbilled summary as usual.
+2. The system applies the matter's retainer balance to the invoice total.
+3. If retainer covers it: client pays $0; balance reduces; you receive the funds via your trust-routing config.
+4. If retainer falls short: client pays the difference via Stripe; future invoices keep drawing from the balance.
+5. Send a **top-up invoice** when the balance gets low — same flow, but the line item is a retainer draw, not time entries.
 
-### What if I need to collect payment immediately?
+## Refunding an invoice
 
-Use a [Payment Link](/payments/accepting-payments) instead of an invoice. Invoices require a due date of at least one day in the future.
+Open the paid invoice → **Refund**. Refunds use Stripe's API; the invoice records the refund and notifies the client. Partial refunds are supported.
 
-### Will I be notified when a client pays an invoice?
+## When to use a payment link instead
 
-Yes. You’ll receive an email notification when a payment is completed, and it will also appear in your dashboard in real time.
+Invoices require a due date of at least the next day. If you need to collect immediately (consultation fee, retainer top-up, donation), use a pre-filled **payment link** instead:
+
+```
+https://blawby.com/your-firm-slug?amount=12500
+```
+
+`amount` in cents. See [Accepting Payments](/payments/accepting-payments) for the full payment link flow.
+
+## Common questions
+
+**Can I invoice without a matter?**
+Most invoicing flows through a matter. For one-off charges that aren't matter-bound, use payment links.
+
+**Do invoices include my firm branding?**
+Yes — your firm name, accent color, and logo (configured in **Settings → Practice**) appear on every invoice and Stripe checkout page.
+
+**Will I be notified when a client pays?**
+Yes — in-app, email, and (if subscribed) push notification. The matter's Activity tab also logs the change.
+
+**Can I edit a sent invoice?**
+No — sent invoices are immutable. To correct a mistake, void or refund and generate a new one. The audit trail preserves both.
+
+## Next steps
+
+- See the matter context: [Matters Overview](/features/matters-overview).
+- Set up payouts so your invoiced revenue lands in your bank: [Payouts](/payments/payouts).
+- Set up your fee model: [Future-Proof Revenue](/business-strategy/future-proof-revenue).
+
+---
+
+Ready to invoice clients with less admin? [Register for Blawby.](https://ai.blawby.com/register)

--- a/src/data/lessons/invoicing.mdx
+++ b/src/data/lessons/invoicing.mdx
@@ -55,7 +55,7 @@ This page covers the operational flow. For the broader matter context — billin
 
 <DocPlaceholder
   kind="screenshot"
-  src="/docs/billing/generate-invoice.png"
+  src="/media/docs/billing/generate-invoice.png"
   description="Billing tab on a matter — unbilled summary expanded, Generate invoice CTA highlighted, draft preview to the right."
 />
 

--- a/src/data/lessons/payouts.mdx
+++ b/src/data/lessons/payouts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Manage Payouts and Revenue Distribution Securely"
 metaTitle: "Payouts | Blawby Legal Payments"
-desc: "Set up and manage Blawby payouts so client funds route correctly and your firm can monitor transfer timing with confidence."
+desc: "Configure Stripe Connect, route trust-eligible funds correctly, and monitor payout timing in your Blawby dashboard."
 image: "https://imagedelivery.net/Frxyb2_d_vGyiaXhS5xqCg/527f8451-2748-4f04-ea0f-805a4214cd00/public"
 author: "Paul Chris Luke"
 authorImage: "/images/logo.png"
@@ -9,104 +9,129 @@ category: "payments"
 contentType: "lesson"
 order: 50
 createdAt: "01/01/2024"
-updatedAt: "01/01/2024"
+updatedAt: "05/07/2026"
+lastVerified: "05/07/2026"
 tags:
   - Payouts
-  - Transfers
-  - Withdrawals
+  - Stripe-Connect
+  - Trust-Account
 keywords:
   - Law firm payouts
+  - Stripe Connect law firm
   - Trust account payouts
-  - Legal payment transfers
-  - Blawby payouts
+  - Blawby payouts schedule
   - IOLTA payout flow
 targetAudience: "practice-owners"
 searchIntent: "informational"
 primaryKeyword: "law firm payouts"
-secondaryKeywords: ["bank transfers", "withdrawals", "fast transfers"]
-summary: "Configure and monitor payouts in Blawby so your payment operations remain predictable and compliant."
+secondaryKeywords: ["stripe connect", "trust account payouts", "fast transfers"]
+summary: "Configure Stripe Connect and trust routing in Blawby so payouts are timely, traceable, and compliant."
 schemaType: "Article"
 faq:
-  - question: "Do I have to use a trust account for payouts?"
-    answer: "Yes. To remain compliant with IOLTA rules, Blawby requires you to use your law firm’s trust account for all payouts."
-  - question: "Are processing fees deducted from client payments?"
-    answer: "No. Blawby advances all processing fees up front and bills them to your operating account on a 30-day cycle. Client payments are deposited in full."
+  - question: "Where do I configure my payout bank account?"
+    answer: "Through Stripe Connect. In Blawby, open Settings → Payments and click Connect Stripe — Stripe's hosted onboarding handles bank linking and identity verification. Blawby never stores your bank details."
+  - question: "Are processing fees deducted from trust-eligible client payments?"
+    answer: "No. Trust-eligible payments deposit in full to your trust account. Processing and platform fees are billed separately to a card linked to your operating account."
   - question: "How long does it take to receive funds?"
-    answer: "Credit card payments are typically paid out in 2 business days, and ACH payments in 5 business days. New accounts may experience a temporary 7–14 day delay for their first payout."
-  - question: "What if my payout account fails verification?"
-    answer: "You’ll receive a notification in your dashboard with next steps. Common issues include incorrect routing numbers or missing documents."
-  - question: "Can I update my payout account later?"
-    answer: "Yes. You can update your external payout account details at any time from the Blawby dashboard under Settings > External payout accounts."
+    answer: "Stripe payouts typically settle in 2 business days for cards and 5 for ACH. First payouts on a new connected account commonly take 7–14 days."
 noindex: false
 ---
 
 # Managing Payouts
 
-Blawby's payout system helps law firms manage client payments while staying compliant with trust accounting requirements. With our integrated system, your firm can:
+Blawby uses **Stripe Connect** for payouts. You don't enter routing or account numbers in Blawby — you connect Blawby to Stripe, Stripe handles bank linking and identity verification, and the connected account is what receives your payouts.
 
-- Receive funds directly into your firm's trust account
-- Stay compliant with IOLTA rules by using verified trust account information
-- Access scheduled payouts based on payment method and processing time
-- Simplify fee handling, as Blawby covers processing fees upfront and bills them on a monthly cycle
+This page covers how to set that up, how trust routing works on top of it, and how to monitor payout timing.
 
-Blawby takes care of the operational and compliance complexity behind the scenes, so your firm can focus on practicing law.
+## Setting up payouts
 
-## Setting Up Payouts
+Use the two-checkpoint flow in your Blawby dashboard.
 
-Use the following steps to set up payouts and receive funds with Blawby. This process is designed to ensure IOLTA (trust account) compliance, so you must use your trust account bank information during setup:
+### Checkpoint 1 — Link your bank to Stripe
 
-1. **Navigate to External Payout Accounts.** (1 minute) In your Blawby dashboard, navigate to Settings and click on **External payout accounts**. This is where you will manage your bank account information for payouts.
-2. **Gather Your Trust Account Bank Information.** (2 minutes) Before proceeding, make sure you have the details for your law firm's trust account ready. You will need the account number, routing number, and the name on the account. Using your trust account is required for compliance with legal and financial regulations.
-3. **Submit Business and Representative Information.** (2 minutes) Provide all required business details and upload any necessary documents for verification, such as government-issued identification. Enter your trust account bank information when prompted. Click the **Submit details** button to begin. It's recommended that the person filling out the information is either the owner of the business or someone with a significant role, such as a director or executive.
-4. **Verification and Next Steps.** (1 minute) In most cases, verification is immediate and your account will be eligible to receive payouts right away. If your account is flagged for further verification, you will see an alert in your dashboard guiding you through the next steps. If you have trouble verifying your account, visit [Help & Support](/help) for assistance.
+1. Open **Settings → Payments**.
+2. Click **Connect Stripe**.
+3. You're redirected to Stripe's hosted onboarding. Complete:
+   - Business type, EIN, and registered address.
+   - Beneficial-owner / representative details.
+   - The bank account you want payouts to land in.
+4. On completion, you're redirected back to Blawby. Checkpoint 1 shows **Linked**.
 
-## How It Works
+### Checkpoint 2 — Charges enabled
 
-At the time of each client transaction, Blawby absorbs the processing fees incurred by financial institutions (e.g., credit card networks like American Express or ACH providers). These fees are advanced by Blawby on your behalf and the full transaction amount is credited to your trust account without deductions.
+Stripe verifies your business and identity in the background. For most firms this clears in minutes; occasionally Stripe asks for additional documents (an ID, a business registration). When approved, the second checkpoint shows **Charges enabled**, and you can collect payments.
 
-Blawby tracks all advanced processing fees and applicable platform fees in an accrued fee ledger, which is reconciled and billed on a rolling 30-day cycle. This means you will be invoiced every 30 days for the total of these fees.
+If charges stay pending, open the Stripe dashboard from the Blawby link — Stripe will list anything still needed. The Blawby checkpoint clears automatically once Stripe approves.
 
-For more information on current processing and platform fees, visit [Pricing](/pricing). For payout troubleshooting, see [Help & Support](/help).
+[Read Accept Your First Payment](/quick-start/accept-first-payment) for the full Stripe Connect walkthrough.
 
-## Payout Schedule
+## How trust routing works on top of Stripe
 
-By default, Blawby processes payouts on the following schedule:
+If your firm holds unearned client funds (retainers, settlement deposits, court-fee deposits), configure trust routing in **Settings → Payments → Trust routing**:
 
-- For credit card payments: 2 business days after the payment is received
-- For ACH payments: 5 business days after the payment is received
+- **Trust-eligible payments** route in full to your trust account. Blawby never deducts fees from those dollars.
+- **Processing and platform fees** are charged separately to a card you link to your operating account.
 
-> **Note**: New accounts may have a longer initial payout delay (up to 7–14 days) for the first payout.
+This is the structural difference between Blawby and a generic processor: with Blawby, the gross amount lands in trust; with most processors, fees are netted before deposit.
 
-## Troubleshooting Payouts
+For more on the compliance model, see [IOLTA Compliance Guide](/compliance/iolta-compliance).
 
-If you encounter issues with payouts:
+## Payout schedule
 
-- Check your Blawby Dashboard for any alerts or notifications
-- Verify that your bank account information is correct
-- Ensure your account is in good standing and all verification steps are complete
+Stripe pays out on these defaults for new connected accounts:
 
-## Frequently Asked Questions
+- **Card payments** — typically 2 business days after settlement.
+- **ACH payments** — typically 5 business days after settlement.
+- **First payout on a new account** — often 7–14 days while Stripe completes risk review.
 
-### Do I have to use a trust account for payouts?
+After your first few payouts, your schedule normalizes. You can adjust payout cadence (daily, weekly, monthly) directly in the Stripe dashboard.
 
-Yes. To remain compliant with IOLTA rules, Blawby requires you to use your law firm’s trust account for all payouts.
+## Monitoring payouts
+
+The **Payouts** view in Blawby shows recent payouts with date, amount, and status. Click through to the linked Stripe payout for the per-transaction breakdown. Anything Stripe knows is one click away.
+
+Notifications fire on:
+
+- Payout sent.
+- Payout failed (e.g., bank account closed).
+- Stripe requested additional documentation.
+
+## Troubleshooting
+
+**Charges stuck in pending.**
+Stripe is reviewing documents. The Stripe dashboard will list what's needed. Resolve there; the Blawby checkpoint clears automatically.
+
+**A payout failed.**
+Most common cause: bank account closed or routing changed. Update bank details in the Stripe dashboard. Stripe automatically retries failed payouts.
+
+**The amount paid out doesn't match what I expect.**
+Stripe's payout reports break down per-transaction. Refunds, chargebacks, and disputed amounts are netted from payouts; the report shows each.
+
+**A specific transaction didn't pay out.**
+Check the matter or invoice the payment was tied to. ACH settlement takes a few business days; high-risk transactions may be held briefly by Stripe.
+
+## Frequently asked questions
+
+### Where do I configure my bank account?
+
+Through Stripe Connect, not in Blawby directly. **Settings → Payments → Connect Stripe** sends you to Stripe's hosted onboarding. Update bank details later from the Stripe dashboard.
+
+### Do I have to use a trust account?
+
+Not unless your firm holds unearned client funds. If you do, configure trust routing — required for IOLTA compliance.
 
 ### Are processing fees deducted from client payments?
 
-No. Blawby advances all processing fees up front and bills them to your operating account on a 30-day cycle. Client payments are deposited in full.
+Not from trust-eligible payments. Trust dollars deposit in full; fees are billed separately to your operating-account card.
 
-### How long does it take to receive funds?
+### How fast are payouts?
 
-Credit card payments are typically paid out in 2 business days, and ACH payments in 5 business days. New accounts may experience a temporary 7–14 day delay for their first payout.
-
-### What if my payout account fails verification?
-
-You’ll receive a notification in your dashboard with next steps. Common issues include incorrect routing numbers or missing documents.
+T+2 for cards, T+5 for ACH on established accounts. New accounts: 7–14 days for the first payout, then normal schedule.
 
 ### Can I update my payout account later?
 
-Yes. You can update your external payout account details at any time from the Blawby dashboard under **Settings > External payout accounts**.
+Yes — directly in the Stripe dashboard. Blawby reads the connected account; any change in Stripe takes effect immediately.
 
 ---
 
-Ready to streamline your law firm's payouts? [Register for Blawby](https://ai.blawby.com/register) or [contact support](https://ai.blawby.com/contact) to get started.
+Ready to set up payouts? [Register for Blawby](https://ai.blawby.com/register) or [contact support](https://ai.blawby.com/contact).

--- a/src/data/solutions/ai-chat/ai-chat-client-acquisition.mdx
+++ b/src/data/solutions/ai-chat/ai-chat-client-acquisition.mdx
@@ -73,7 +73,7 @@ This matters for client acquisition because most generic chatbots run one mode â
 
 <DocPlaceholder
   kind="diagram"
-  src="/docs/ai-chat/intent-routing.svg"
+  src="/media/docs/ai-chat/intent-routing.svg"
   description="Diagram of the intent classifier â€” first message routes to REQUEST_CONSULTATION, ASK_QUESTION, or CONVERSATION based on signal."
 />
 

--- a/src/data/solutions/ai-chat/ai-chat-client-acquisition.mdx
+++ b/src/data/solutions/ai-chat/ai-chat-client-acquisition.mdx
@@ -1,7 +1,7 @@
 ---
-title: "AI Chat Client Acquisition"
+title: "AI Chat Client Acquisition for Law Firms"
 metaTitle: "AI Chat Client Acquisition for Law Firms | Blawby"
-desc: "Use AI chat strategy to improve legal lead capture, qualification, and after-hours client engagement for your law firm."
+desc: "How Blawby's AI chat captures, qualifies, and converts website visitors into paying clients — with the real intent modes, languages, and integration points."
 image: "https://imagedelivery.net/Frxyb2_d_vGyiaXhS5xqCg/527f8451-2748-4f04-ea0f-805a4214cd00/public"
 author: "Paul Chris Luke"
 authorImage: "/images/logo.png"
@@ -9,7 +9,8 @@ category: "ai-chat"
 contentType: "article"
 order: 10
 createdAt: "02/01/2024"
-updatedAt: "02/01/2024"
+updatedAt: "05/07/2026"
+lastVerified: "05/07/2026"
 tags:
   - AI-Chat
   - Client-Acquisition
@@ -19,306 +20,147 @@ keywords:
   - AI chat for law firms
   - Legal client acquisition
   - Law firm lead generation
-  - Legal chatbot
-  - Legal intake chat
-  - After hours legal intake
+  - AI legal intake
+  - 24/7 legal intake
 targetAudience: "practice-owners"
 searchIntent: "commercial"
 primaryKeyword: "ai chat for law firms"
 secondaryKeywords:
-  ["legal chatbot", "client acquisition automation", "website lead generation"]
-summary: "Transform your website into a 24/7 client acquisition tool with AI chat that understands legal clients and converts visitors."
+  ["legal chatbot", "client acquisition automation", "legal AI intake"]
+summary: "Turn your website into a 24/7 client acquisition surface with Blawby's mode-aware AI chat that intakes, qualifies, and converts in 18 languages."
 schemaType: "Article"
 faq:
-  - question: "How does AI chat help with client acquisition?"
-    answer: "AI chat engages visitors immediately, qualifies leads 24/7, and captures contact information even when you're unavailable, increasing conversion rates by 3-5x."
-  - question: "Is AI chat compliant with legal ethics rules?"
-    answer: "Our AI chat is designed to follow common legal ethics best practices by providing general information, scheduling consultations, and avoiding specific legal advice. Clients should always consult an attorney for legal advice."
+  - question: "What does Blawby's chat actually do?"
+    answer: "It runs a mode-aware conversation: REQUEST_CONSULTATION drives a structured intake against your template, ASK_QUESTION handles light questions, and CONVERSATION drives post-acceptance two-way chat. The AI routes incoming messages to the right mode automatically."
+  - question: "Is the AI giving legal advice?"
+    answer: "No. The AI is built to surface intake context and route to a real attorney; it does not provide jurisdiction-specific legal advice. Your firm's disclaimer and acknowledgment language are configurable per intake template."
+  - question: "How many languages does it support?"
+    answer: "18 languages with full RTL for Arabic. The widget detects browser language; clients can switch."
 noindex: false
 ---
 
-# AI Chat Setup: Transform Your Website into a 24/7 Client Acquisition Tool
+# AI Chat Client Acquisition for Law Firms
 
-Stop losing potential clients because they can't reach you after hours. AI chat transforms your website from a digital brochure into an active client acquisition tool that works around the clock.
+Most firm websites are static brochures. The lead either fills a contact form (low conversion, slow response) or doesn't bother. Blawby's chat turns that surface into a 24/7 intake worker — qualifying clients in their language, collecting the structured facts your team needs to triage, and gating on a consultation fee when your policy requires.
 
-## Why AI Chat Beats Contact Forms
+This article is the strategy version. For the operational setup, see [Set Up Client Intake](/features/set-up-client-intake) and [Intake Templates](/features/intake-templates).
 
-Traditional contact forms have a 2-5% conversion rate. AI chat achieves 15-25% by engaging visitors immediately, answering their questions, and collecting information conversationally.
+## Why structured AI beats a contact form
 
-**The difference is engagement:**
+A contact form is one event: name, email, message, send. The lead either filled it correctly or didn't, and you find out hours later when someone checks the inbox. Several things go wrong by default:
 
-- **Contact forms**: Passive, require effort, delayed response
-- **AI chat**: Active conversation, instant engagement, qualified leads
+- **Drop-off** — long forms feel like work; conversion drops with each required field.
+- **Sparse data** — even when filled, you usually get a free-text "I have a question" with no urgency, jurisdiction, or matter type.
+- **Slow first response** — most leads expect a reply in minutes, not the next morning.
+- **No language coverage** — if your client base isn't English-only, the form excludes them.
 
-## Before You Begin: Strategy First
+Blawby chat solves all four with structure: the AI asks one thing at a time, validates as it goes, conducts the conversation in the client's language, and submits to a notification-routed queue.
 
-### Define Your Goals
+## How the chat actually works
 
-What do you want your AI chat to accomplish?
+The chat surface is **mode-aware**. The AI doesn't just have one personality — it routes the first message into one of four modes and behaves accordingly:
 
-- **Lead Generation**: Capture contact information and case details
-- **Client Qualification**: Filter out non-ideal cases automatically
-- **Appointment Setting**: Schedule consultations directly
-- **General Information**: Answer common questions about your practice
+| Mode | What it does | When it fires |
+|---|---|---|
+| `REQUEST_CONSULTATION` | Conducts a structured intake against your template. Required → enrichment → fee → submit. | First message that signals a real legal need. |
+| `ASK_QUESTION` | Lightweight one-off response, no funnel. | Casual or informational queries (e.g. "what areas do you handle?"). |
+| `PRACTICE_ONBOARDING` | The conversational setup flow when you first sign up. | Internal — only at firm onboarding. |
+| `CONVERSATION` | Two-way attorney-led thread, AI assists. | After the firm accepts an intake. |
 
-### Know Your Ideal Client
+You don't pick the mode manually. The platform classifies the first message and routes it.
 
-Your AI chat should reflect your practice's personality and focus. Consider:
+This matters for client acquisition because most generic chatbots run one mode — every visitor gets the same script regardless of intent. Blawby's classifier separates "I'm curious about your firm" (don't run a 10-question intake) from "I was in an accident yesterday" (run the intake right now).
 
-- Practice areas you want to emphasize
-- Types of cases you're currently seeking
-- Client demographics you serve best
-- Your unique value proposition
+<DocPlaceholder
+  kind="diagram"
+  src="/docs/ai-chat/intent-routing.svg"
+  description="Diagram of the intent classifier — first message routes to REQUEST_CONSULTATION, ASK_QUESTION, or CONVERSATION based on signal."
+/>
 
-## Step 1: Configure Your AI Personality
+## Reach: 18 languages, full RTL
 
-### Choose Your Tone
+The AI runs intake in 18 languages out of the box:
 
-**Professional & Formal**
+- Americas: English, Spanish, Portuguese, French
+- Europe: English, Spanish, French, German, Russian, Italian, Dutch, Polish, Ukrainian
+- Asia: Chinese, Japanese, Vietnamese, Korean, Thai, Indonesian, Hindi
+- Middle East / Africa: Arabic (full right-to-left rendering), French, English
 
-- Best for: Corporate law, litigation, established firms
-- Example: "Thank you for your interest. How may I assist you with your legal matter today?"
+The widget detects browser language. Clients can switch. RTL languages render fully right-to-left across all surfaces — including the engagement letter the firm later sends.
 
-**Approachable & Friendly**
+For firms serving immigrant communities, multilingual practice areas, or international cases, this is the difference between capturing a lead and losing one.
 
-- Best for: Family law, estate planning, solo practices
-- Example: "Hi there! I'm here to help you understand your legal options. What's on your mind?"
+## Trust building: the AI's tone
 
-**Efficient & Direct**
+The intake AI is built around two principles:
 
-- Best for: High-volume practices, transactional work
-- Example: "What type of legal assistance do you need? I can connect you with the right attorney."
+1. **Help before asking.** The opening turn provides value (clarifying what's covered, what to expect) before requesting personal info.
+2. **No legal advice.** The AI is intake-and-route, not advise-and-resolve. Disclaimers are configurable per template; the AI honors them.
 
-## Step 2: Set Up Knowledge Base
+A typical first turn for a `REQUEST_CONSULTATION` intake:
 
-### Frequently Asked Questions
+> Hi — I can help you understand whether our firm can help with your situation. Tell me what happened and I'll ask a few follow-ups.
 
-Your AI should handle common questions automatically:
+That's it. No 12-field form on screen. The AI then collects the required fields one at a time, with conditional follow-ups, and submits to your queue.
 
-**Service-Related:**
+## Conversion lever: consultation fees in chat
 
-- "What are your fees?"
-- "Do you offer free consultations?"
-- "How long have you been practicing?"
-- "What areas of law do you handle?"
+For firms with a paid first consultation, the most common drop-off is "the website didn't tell me how to pay." Blawby's intake template can require payment before submission — the Stripe payment card renders inline in chat, between the contact-collection step and submission confirmation. The client pays without leaving the conversation.
 
-**Process-Related:**
+This isn't optional friction; it's a qualifier. Clients who pay for a consult are more committed than those who fill a form, and the firm's first response is to a paying lead, not a free one.
 
-- "How do I schedule an appointment?"
-- "What should I bring to my consultation?"
-- "How long does a typical case take?"
-- "Do you represent clients in my area?"
+[Read more in Intake Templates](/features/intake-templates).
 
-### Practice-Specific Information
+## After-hours: the queue keeps running
 
-Add details that set you apart:
+The chat runs 24/7. Submissions stack in your queue overnight; notifications fire to your team via in-app, email, and (optionally) push (OneSignal).
 
-- **Success stories** (without violating confidentiality)
-- **Unique processes** or methodologies
-- **Special certifications** or recognitions
-- **Community involvement** or accolades
+What this lets you optimize:
 
-## Step 3: Configure Conversation Flow
+- **First response time** — the most-correlated metric for legal-lead conversion. Push notifications mean a same-hour response is realistic even after hours.
+- **Coverage gaps** — define a backup intake owner so vacations and holidays don't sink the queue.
+- **Triage policy** — paralegals can do first-pass triage; attorneys review only the ones that pass.
 
-### Welcome Message Strategy
+## Integration: where chat fits in the broader funnel
 
-Your first message sets the tone:
+The chat doesn't operate alone. The end-to-end conversion path on Blawby:
 
-**Effective examples:**
+1. **Widget** on your website → `REQUEST_CONSULTATION` mode runs your template.
+2. **Submission** lands in the **Intakes queue** with AI-generated summary and urgency.
+3. **Triage** — accept (creates matter), decline, or "ask AI for more info."
+4. **Conversation** — `CONVERSATION` mode after acceptance; attorney-led with AI assist.
+5. **Engagement** — structured letter sent from the matter, signed in-thread.
+6. **Payment** — retainer or initial fee collected after acceptance.
+7. **Active matter** — time, files, invoicing all from the matter detail.
 
-- "I'm your virtual assistant. I can help you understand if we're the right fit for your legal needs and connect you with an attorney."
-- "Welcome! I'm here to answer your questions and see if our firm can help with your situation."
-- "Hi! I can help you explore your legal options and schedule a free consultation if appropriate."
+Each step has its own page in the docs. The point: chat is the entry, not the entire workflow.
 
-### Question Sequence Design
+## Practical performance metrics
 
-Structure your conversation like a natural interview:
+Track these monthly:
 
-1. **Broad opening**: "What brings you here today?"
-2. **Clarification**: "Can you tell me more about [specific issue]?"
-3. **Context gathering**: "When did this happen? Where are you located?"
-4. **Qualification**: "Have you spoken with other attorneys about this?"
-5. **Next steps**: "Based on what you've shared, I'd recommend..."
-
-### Fallback Handling
-
-Prepare for unexpected questions:
-
-- **Out of scope**: "I'm not able to help with [topic], but I can connect you with an attorney who can."
-- **Complex issues**: "That sounds like a complex matter. Let me schedule a consultation for you."
-- **Emergency situations**: "If this is an emergency, please call 911 or contact local authorities immediately."
-
-## Step 4: Integration with Your Workflow
-
-### Lead Routing
-
-Where should qualified leads go?
-
-- **Direct to attorneys** - For urgent matters
-- **Intake specialist** - For initial screening
-- **Calendar system** - For automatic scheduling
-- **CRM integration** - For tracking and follow-up
-
-### Notification Systems
-
-Set up alerts for different types of conversations:
-
-- **High-priority leads** - Immediate notification
-- **After-hours inquiries** - Morning summary
-- **General questions** - Weekly digest
-- **System issues** - Technical alerts
-
-### Data Collection Standards
-
-Ensure your AI captures essential information:
-
-**Required for every lead:**
-
-- Name and contact information
-- Case type and basic details
-- Geographic location
-- Urgency level
-
-**Optional but valuable:**
-
-- Budget considerations
-- Previous attorney experience
-- Preferred communication method
-- Referral source
-
-## Step 5: Testing and Optimization
-
-### Test Scenarios
-
-Run through common conversation paths:
-
-1. **New personal injury case**
-2. **Family law consultation request**
-3. **Business formation inquiry**
-4. **General legal information question**
-5. **Non-legal question (out of scope)**
-
-### Performance Metrics
-
-Track these key indicators:
-
-- **Conversation completion rate** - % of chats that reach the end
-- **Lead qualification rate** - % of chats that become qualified leads
-- **Contact information capture** - % of chats with complete contact details
-- **User satisfaction** - Post-chat ratings when available
-
-### Continuous Improvement
-
-Review conversations weekly:
-
-- Identify common questions not in your knowledge base
-- Note conversation points where users drop off
-- Look for patterns in successful vs. unsuccessful conversations
-- Update your AI's responses based on real interactions
-
-## Advanced Features
-
-### Multilingual Support
-
-If you serve diverse communities:
-
-```javascript
-// Enable Spanish support
-blawby("init", {
-  practiceId: "YOUR_PRACTICE_ID",
-  languages: ["en", "es"],
-  defaultLanguage: "en",
-});
-```
-
-### Custom Branding
-
-Match your website's look and feel:
-
-```javascript
-blawby("init", {
-  practiceId: "YOUR_PRACTICE_ID",
-  customColors: {
-    primary: "#1e40af", // Your brand blue
-    secondary: "#3b82f6", // Lighter blue
-    accent: "#f59e0b", // Accent color
-  },
-  customFont: "Inter",
-  logoUrl: "https://your-site.com/logo.png",
-});
-```
-
-### Integration with Calendars
-
-Automatically schedule consultations:
-
-```javascript
-blawby("init", {
-  practiceId: "YOUR_PRACTICE_ID",
-  calendarIntegration: {
-    provider: "calendly", // or 'google-calendar', 'microsoft-outlook'
-    calendarId: "YOUR_CALENDAR_ID",
-    availableSlots: "next-7-days",
-  },
-});
-```
-
-## Common Pitfalls to Avoid
-
-### Over-Automation
-
-Don't make your AI too robotic. Keep conversations natural and empathetic, especially for sensitive legal matters.
-
-### Inadequate Training
-
-Spend time upfront training your AI with real scenarios from your practice. The more specific your training, the better the results.
-
-### Ignoring Analytics
-
-Don't set it and forget it. Regular review of conversation data helps you improve both the AI and your overall client acquisition strategy.
-
-### Privacy Violations
-
-Never ask for sensitive information in initial conversations. Guide users to secure channels for confidential details.
-
-## Measuring Success
-
-### Key Performance Indicators
-
-Track these metrics monthly:
-
-- **Lead volume increase** - Compare to pre-AI chat baseline
-- **Lead quality improvement** - Higher qualification rates
-- **Response time reduction** - Faster initial engagement
-- **Cost per acquisition** - Lower marketing costs
-- **Client satisfaction** - Better onboarding experience
-
-### ROI Calculation
-
-Calculate your AI chat return on investment:
-
-```
-ROI = (Value of new clients from AI chat - Cost of AI chat) / Cost of AI chat × 100
-```
-
-Include factors like:
-
-- Reduced staff time on initial screening
-- Higher conversion rates from better engagement
-- Improved client experience leading to referrals
-- 24/7 availability capturing after-hours leads
-
-## Next Steps
-
-Your AI chat is now configured and ready to transform your client acquisition.
-
-1. **Monitor your first week** of conversations closely
-2. **Gather feedback** from staff and clients
-3. **Refine your responses** based on real interactions
-4. **Scale up** your AI chat presence across all marketing channels
+- **Visit-to-conversation rate** — % of widget visitors who send a first message.
+- **Conversation-to-submission rate** — % of started conversations that complete intake.
+- **Submission-to-accept rate** — your team's triage decisions.
+- **Accept-to-engagement rate** — how many accepts actually sign.
+- **Engagement-to-paid rate** — payment completion.
+- **Median time to first response** — your firm's SLA on triage.
+
+If conversation-to-submission is low, your template likely has too many required fields. If submission-to-accept is low, the AI isn't qualifying tightly enough — adjust template or services list.
+
+## Common pitfalls
+
+- **Over-automating the conversation.** Once you've accepted, switch to attorney-led mode. Clients can tell when they're still talking to a bot post-acceptance, and trust drops.
+- **Skipping the disclaimer.** Configure your template's pre-collection disclaimer once; don't omit it because "the AI seems helpful enough."
+- **Treating the widget as set-and-forget.** Review submissions weekly for the first month; refine template fields where clients consistently leave answers blank or off-target.
+- **No multilingual fallback.** If your client base includes Spanish or other non-English speakers, leave the language switcher visible — it's enabled by default.
+
+## Next steps
+
+- Configure your widget: [Install the Chat Widget](/ai-chat/install-chat-widget).
+- Build your template: [Intake Templates](/features/intake-templates).
+- Tune your queue: [Review and Triage Client Intakes](/features/review-and-triage-intake).
 
 ---
 
-## Ready to Capture More Clients?
-
-Your AI chat is now positioned to engage visitors 24/7, qualify leads automatically, and streamline your intake process. [Access your dashboard](https://dashboard.blawby.com) to monitor performance and optimize your setup.
+Ready to put your firm on a 24/7 intake surface? [Start your setup.](https://ai.blawby.com/register)

--- a/src/data/solutions/ai-chat/install-chat-widget.mdx
+++ b/src/data/solutions/ai-chat/install-chat-widget.mdx
@@ -9,7 +9,8 @@ category: "ai-chat"
 contentType: "guide"
 order: 30
 createdAt: "02/10/2024"
-updatedAt: "04/30/2026"
+updatedAt: "05/07/2026"
+lastVerified: "05/07/2026"
 tags:
   - Installation
   - Widget
@@ -98,37 +99,24 @@ If your website uses a builder, you can usually add the widget without coding.
 
 Use this section if your web developer wants script-level installation.
 
-```html
-<script>
-  (function (w, d, s, o, f, js, fjs) {
-    w["BlawbyWidget"] = o;
-    w[o] =
-      w[o] ||
-      function () {
-        (w[o].q = w[o].q || []).push(arguments);
-      };
-    js = d.createElement(s);
-    fjs = d.getElementsByTagName(s)[0];
-    js.async = 1;
-    js.src = f;
-    fjs.parentNode.insertBefore(js, fjs);
-  })(
-    window,
-    document,
-    "script",
-    "blawby",
-    "https://widget.blawby.com/embed.js",
-  );
+> **Get the exact snippet from your dashboard.** Open your practice's widget settings in Blawby and copy the install code shown there — it includes your firm's slug, default styling, and any locale options you've configured. The example below shows the shape of what you'll see; the canonical version comes from the dashboard.
 
-  blawby("init", {
-    practiceId: "YOUR_PRACTICE_ID",
-    position: "bottom-right",
-    theme: "light",
-  });
-</script>
+```html
+<script
+  async
+  src="https://ai.blawby.com/widget/embed.js?slug=YOUR_PRACTICE_SLUG"
+></script>
 ```
 
-Replace `YOUR_PRACTICE_ID` with your practice ID from Blawby.
+Replace `YOUR_PRACTICE_SLUG` with the slug shown in your practice settings (e.g. `acme-law`).
+
+### What the widget supports out of the box
+
+- **AI-guided intake** in 18 languages with full RTL for Arabic.
+- **File uploads** up to 25 MB per file (images, video, audio, PDF, Word).
+- **Optional consultation fees** — gate submission on a Stripe payment when you've configured one for the intake template.
+- **Conditional fields** — the AI only asks follow-up questions when a parent answer matches.
+- **Practice branding** — your firm's name, logo, and accent color, configured in the dashboard (no code changes needed).
 
 ## Next Step
 

--- a/src/data/solutions/ai-chat/modern-intake-flow.mdx
+++ b/src/data/solutions/ai-chat/modern-intake-flow.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Modern Intake Flow: Convert Visitors to Clients"
+title: "Modern Intake Flow: Visitor to Paying Client"
 metaTitle: "Modern Intake Flow for Law Firms | Blawby"
-desc: "Learn a practical intake conversation model that helps law firms convert anonymous website visitors into qualified client conversations."
+desc: "Convert anonymous visitors to paying clients — required vs. enrichment fields, conditional logic, and consultation-fee gating in Blawby."
 image: "https://imagedelivery.net/Frxyb2_d_vGyiaXhS5xqCg/527f8451-2748-4f04-ea0f-805a4214cd00/public"
 author: "Paul Chris Luke"
 authorImage: "/images/logo.png"
@@ -9,286 +9,162 @@ category: "ai-chat"
 contentType: "article"
 order: 20
 createdAt: "02/05/2024"
-updatedAt: "02/05/2024"
+updatedAt: "05/07/2026"
+lastVerified: "05/07/2026"
 tags:
   - Client-Intake
   - Client-Acquisition
   - AI-Chat
-  - Automation
+  - Conversion
 keywords:
   - Law firm intake automation
   - Legal lead conversion
   - Anonymous visitor to client
-  - Legal website intake chat
+  - Conditional intake fields
 targetAudience: "practice-owners"
 searchIntent: "commercial"
 primaryKeyword: "client intake automation"
 secondaryKeywords: ["lead conversion", "anonymous to client", "legal intake"]
-summary: "Transform anonymous website visitors into paying clients through AI-powered conversations and modern intake automation."
+summary: "A practical intake conversation model for law firms — required vs. enrichment fields, conditional logic, fee gating — that converts anonymous visitors to paying clients."
 schemaType: "Article"
 faq:
-  - question: "How do you convert anonymous visitors to clients?"
-    answer: "Through AI-powered conversations that build trust, qualify leads, and seamlessly capture contact information when visitors are ready to engage."
-  - question: "Is anonymous-to-client conversion compliant with legal ethics?"
-    answer: "Yes, our system maintains compliance by providing general information, avoiding specific legal advice, and properly transitioning to attorney-client relationships."
+  - question: "What's the most important conversion lever in legal intake?"
+    answer: "Keeping the required-fields list short. Each additional required field is a chance for the visitor to drop. Move everything except true triage essentials into the post-submit enrichment phase."
+  - question: "Should we charge a consultation fee at intake?"
+    answer: "If your firm policy is paid consultations, gating submission on a fee qualifies the lead. Free-consult firms should leave the fee off — gating on a $0 charge is wasted friction."
 noindex: false
 ---
 
-# From Anonymous Visitor to Paying Client: The Modern Intake Flow
+# Modern Intake Flow: Anonymous Visitor to Paying Client
 
-Transform anonymous website visitors into authenticated clients through a seamless AI-powered conversation flow that captures information, builds trust, and converts prospects into paying clients.
+Most law firm websites lose 80%+ of their visitors at intake. The flow is wrong: a long contact form, a slow first response, no language coverage, no qualification before a human is paged. Visitors who came ready to engage bounce to a competitor who made it easier.
 
-## The Traditional Intake Problem
+This article is the conversion-design version. For the operational template setup see [Intake Templates](/features/intake-templates).
 
-Many law firms lose a significant portion—sometimes up to 80%—of website visitors because their intake process creates friction:
+## Where the funnel actually breaks
 
-- **Contact forms** feel impersonal and require effort
-- **Phone calls** interrupt prospects and create pressure
-- **Email exchanges** are slow and inefficient
-- **Consultation scheduling** is often clunky and time-consuming
+| Step | Common breakage |
+|---|---|
+| Visitor arrives | Bounce because there's no clear "talk now" option. |
+| Visitor opens chat | Scripted bot demands a name before saying anything useful. |
+| Visitor describes situation | Form treats their answer as a single field; no follow-ups. |
+| Visitor reaches contact ask | Form requires too much; they bail. |
+| Submission arrives | Goes to a generic inbox, no SLA, hours pass. |
+| First firm response | Generic reply that doesn't acknowledge their situation. |
+| Consultation booking | Email back-and-forth to find a slot. |
 
-The result? Potential clients bounce to competitors who make it easier to get help.
+Each row is a conversion drop. Fix one, lift the funnel a little; fix all of them, the firm's intake becomes a real revenue surface.
 
-## The Anonymous-to-Authenticated Solution
+## The four-stage flow Blawby runs
 
-AI chat creates a natural progression from anonymous browsing to authenticated client relationship:
+### Stage 1 — Anonymous engagement (first 0–2 minutes)
 
-```
-Anonymous Visitor → Engaged Conversation → Qualified Lead → Authenticated Client
-```
+Goal: provide value, establish credibility, don't ask for anything yet.
 
-This flow respects the prospect's journey while capturing essential information at each stage.
+The AI's first turn:
 
-## Understanding the User Psychology
+> I can help you understand whether our firm can help. Tell me what happened.
 
-### Why Visitors Stay Anonymous
+No name field. No phone request. The visitor types a sentence; the AI responds with relevant context (sympathy where appropriate, jurisdiction-aware framing, plain-language clarification). They've engaged before any "personal info" boundary was crossed.
 
-- **Privacy concerns** - They're not ready to share personal information
-- **Information gathering** - They're comparing options and doing research
-- **Fear of commitment** - They don't want to be pressured into hiring
-- **Testing the waters** - They want to see if you're credible and helpful
+### Stage 2 — Trust building (2–5 minutes)
 
-### What Converts Anonymous Visitors
+Goal: show domain knowledge by asking the right follow-ups.
 
-- **Immediate value** - Helpful answers without requiring personal information
-- **Gradual trust building** - Demonstrate expertise before asking for anything
-- **Clear next steps** - Show them exactly what happens next
-- **No-pressure environment** - Let them control the pace
+The AI uses your **template's required fields** to drive structured follow-up: matter type, brief case summary, jurisdiction, urgency. Each question is asked one at a time, with conditional logic via `dependsOn` so irrelevant questions never appear:
 
-## Designing Your Anonymous-to-Authenticated Flow
-
-### Stage 1: Anonymous Engagement (0-2 minutes)
-
-**Goal**: Provide immediate value and establish credibility
-
-**AI Approach**: Be helpful, informative, and non-intrusive
-
-**Sample Conversation**:
-
-```
-AI: Hi! I'm here to help you understand your legal options. What brings you here today?
-
-Visitor: I was in a car accident last week and I'm not sure what to do.
-
-AI: I'm sorry to hear that. Car accidents can be overwhelming. Let me help you understand the immediate steps you should take, regardless of whether you decide to hire an attorney. Have you sought medical attention yet?
+```yaml
+- key: court_date
+  label: "When is your next court date?"
+  type: date
+  dependsOn:
+    field: has_open_case
+    value: true
 ```
 
-**Key Principles**:
+The visitor experiences competence: the AI is asking the questions a paralegal would ask, in the right order.
 
-- Focus on helping, not selling
-- Provide value immediately
-- Don't ask for personal information yet
-- Demonstrate expertise through helpful guidance
+### Stage 3 — Qualification (5–8 minutes)
 
-### Stage 2: Trust Building (2-5 minutes)
+Goal: confirm fit, surface deal-breakers (jurisdiction, conflict, urgency mismatch).
 
-**Goal**: Establish credibility and show you understand their situation
+The AI asks any remaining required fields and starts noting urgency. If your services list excludes the matter type, the AI surfaces that politely without forcing the visitor to discover it via decline.
 
-**AI Approach**: Ask relevant questions that show expertise while building rapport
+### Stage 4 — Authentication and (optionally) payment
 
-**Sample Conversation**:
+Goal: collect contact info; if your policy is paid consults, collect the fee.
 
-```
-AI: Based on what you've shared, it sounds like you may have a personal injury case. In our experience, cases like yours typically involve medical expenses, lost wages, and property damage. Have you documented any of these costs so far?
+Now the AI asks for name, email, and phone. The framing matters: "What's the best way to reach you so an attorney can review this and follow up?" — not "Please provide your contact information for our records."
 
-Visitor: I have some medical bills and my car is still in the shop.
+If your template has a **consultation fee**, the Stripe payment card renders inline in the chat thread between contact collection and submission confirmation. The visitor pays without leaving the conversation.
 
-AI: That's good documentation. The fact that you're already keeping records will help significantly. We've handled hundreds of cases like yours, and proper documentation makes a big difference in outcomes. Would you like me to walk you through what typically happens in these cases?
-```
+<DocPlaceholder
+  kind="screenshot"
+  src="/docs/intake/four-stage-flow.png"
+  description="Annotated chat screenshot showing all four stages — engagement, trust building, qualification, authentication + fee — in one continuous thread."
+/>
 
-**Key Principles**:
+## Why required vs. enrichment fields matter
 
-- Show experience with similar cases
-- Provide valuable insights
-- Gradually introduce your expertise
-- Still avoid asking for contact information
+The single highest-leverage decision in template design: which fields gate submission, and which become "strengthen your case" enrichment.
 
-### Stage 3: Qualification (5-8 minutes)
+**Required fields** must be filled before submission. Each one is a drop-off risk. Keep this list to ≤5 — typically: contact, matter type, case summary, jurisdiction, urgency.
 
-**Goal**: Determine if they're a good fit while maintaining trust
+**Enrichment fields** are offered after submission. The visitor has already crossed the conversion line; now they're being asked to upgrade the case quality. Drop-off here doesn't lose the lead — you still have the submission.
 
-**AI Approach**: Ask qualifying questions naturally within the helpful conversation
+This is the structural insight most generic chatbots miss. They either gate everything (kills conversion) or gate nothing (lands sparse leads). Blawby's two-phase model lets you collect rich case context **after** the lead is captured.
 
-**Sample Conversation**:
+## Session continuity
 
-```
-AI: To help our team provide the most relevant information, could you share where the accident occurred? Laws and filing deadlines vary significantly by jurisdiction.
+A potential client often pauses mid-intake. They get distracted, switch devices, or just need a minute. If they return, the conversation picks up where it left off — the prior exchanges, the partial answers, all preserved.
 
-Visitor: It happened in California, near Los Angeles.
+This is what makes the four-stage flow practical. Without continuity, every interruption is a lost lead.
 
-AI: Thank you. Filing deadlines for personal injury claims in California can be as short as two years, though specific rules vary. It's important to consult with a licensed attorney to understand the exact timeline for your situation. Our firm works with clients across various jurisdictions, and we'd be happy to have one of our attorneys review your details. Have you spoken with a lawyer about this yet?
-```
+## Multilingual: the lever most firms ignore
 
-**Key Principles**:
+If your client base is anything other than English-only, multilingual intake is the highest-impact change you can make. Blawby runs intake in 18 languages with full RTL for Arabic. The widget detects browser language; clients can switch.
 
-- Ask qualifying questions naturally
-- Provide value with each question
-- Show geographic relevance
-- Still maintain the helpful, non-sales approach
+For firms serving immigrant communities, the math is straightforward: the leads who bounced because they couldn't read the English form weren't bad leads — they were leads you couldn't reach.
 
-### Stage 4: Transition to Authentication (8-10 minutes)
+## Performance metrics worth tracking
 
-**Goal**: Convert anonymous conversation to identifiable lead
+Don't track everything. Track these monthly:
 
-**AI Approach**: Offer clear value in exchange for contact information
+- **Conversation start rate** — visitors who send a first message.
+- **Required-fields completion rate** — % of started intakes that submit.
+- **Submission-to-accept rate** — your triage decisions.
+- **Accept-to-paid rate** — full conversion through engagement and first payment.
+- **Median time to first response** — your firm's SLA on the queue.
 
-**Sample Conversation**:
+If completion rate is low, drop a required field. If accept rate is low, refine your template's qualification questions or your services list. If accept-to-paid is low, look at engagement timing — sending the engagement same-day beats sending it next week.
 
-```
-AI: Based on the details you've shared, this is a situation our attorneys can review in more detail. I can connect you with one of our personal injury lawyers for a free consultation. They can perform a professional assessment and provide specific legal guidance for your case.
+## Practical patterns that work
 
-To set that up, I'll need:
-- Your name
-- Best phone number or email
-- Preferred time for the consultation
+1. **Write the disclaimer once, leave it on.** Pre-collection disclaimer is a trust signal, not a friction point.
+2. **Use conditional fields aggressively.** Visitors notice when a chat asks the right next question, and notice when it asks five irrelevant ones.
+3. **Send the engagement same-day** for any matter you accept. Momentum compounds.
+4. **Never disable session continuity.** Lead-recovery on resumed sessions is a non-trivial percentage.
 
-The consultation is completely free, and there's no obligation to hire us. Would you like to proceed?
-```
+## Where this leaves your team
 
-**Key Principles**:
+When intake is set up well, your queue fills with submissions that have:
 
-- Make the ask clear and specific
-- Explain what happens next
-- Remove pressure (free consultation, no obligation)
-- Ask for minimal information needed
+- Confirmed jurisdiction.
+- Categorized matter type.
+- Urgency level.
+- AI-generated short-form case summary.
+- Documents the client uploaded inline.
+- Paid consultation fee (if your policy).
+- Optional enrichment context to strengthen the case.
 
-## Why Session Handling and Lead Transition Matter
+The first response no longer starts cold. The attorney walks into the consult with a much fuller picture, and conversion rates compound.
 
-For a law firm, the transition from an anonymous visitor to a known prospective client is a critical moment. Proper session handling ensures that if a potential client starts a conversation and then needs to pause or step away, their context isn't lost. This prevents the frustration of having to repeat their situation when they return, which improves the overall intake quality and keeps the momentum toward a consultation.
+## Next steps
 
-### Preserving Client Context
-
-When a visitor engages with your AI chat, they are often sharing sensitive or complex details about their legal needs. By maintaining the continuity of the conversation, your firm demonstrates professional care from the very first interaction. This continuity helps build the trust necessary for them to eventually share their contact information and request a consultation.
-
-### Streamlined Lead Transition
-
-The moment a visitor decides to share their name and contact details, they are signaling their readiness to move forward. A smooth transition from an anonymous chat to a qualified lead record means your staff receives the full history of the interaction. This allows your team to enter the first consultation with a deep understanding of the client's needs, making the initial meeting far more productive.
-
-## Best Practices for Each Stage
-
-### Anonymous Engagement Best Practices
-
-1. **Lead with value, not questions** - Help before you ask
-2. **Use conversational language** - Sound like a helpful human, not a form
-3. **Provide immediate utility** - Give them something useful right away
-4. **Set expectations** - Let them know you're there to help, not pressure
-
-### Trust Building Best Practices
-
-1. **Demonstrate expertise** - Show you understand their situation
-2. **Share relevant experience** - Mention similar cases (without violating confidentiality)
-3. **Be transparent** - Explain what you can and cannot help with
-4. **Maintain helpful tone** - Keep the focus on their needs, not your sales goals
-
-### Qualification Best Practices
-
-1. **Ask questions naturally** - Weave qualifying questions into helpful conversation
-2. **Provide context** - Explain why you need certain information
-3. **Respect boundaries** - Don't push for sensitive details too early
-4. **Show relevance** - Connect their answers to potential solutions
-
-### Authentication Best Practices
-
-1. **Make the ask clear** - Be specific about what you need and why
-2. **Explain the value** - Show what they get in return for their information
-3. **Remove pressure** - Emphasize free consultations and no obligation
-4. **Make it easy** - Ask for minimal information needed to proceed
-
-## Measuring Success
-
-### Key Metrics to Track
-
-**Anonymous Engagement Metrics**:
-
-- Conversation start rate (percentage of visitors who engage)
-- Average conversation length before dropping off
-- Most common conversation paths
-- Drop-off points in the conversation flow
-
-**Conversion Metrics**:
-
-- Anonymous-to-lead conversion rate
-- Time from first message to contact information sharing
-- Lead quality scores (based on conversation content)
-
-**Post-Conversion Metrics**:
-
-- Consultation booking rate from qualified leads
-- Client acquisition rate from consultations
-
-### Measuring Performance
-
-Track these indicators to understand how well your intake flow is performing:
-
-- **Conversation Engagement**: How many visitors feel comfortable starting a dialogue.
-- **Qualification Rate**: How many conversations provide enough detail to determine if the firm can help.
-- **Contact Capture**: How many qualified visitors choose to share their contact information.
-- **Consultation Bookings**: How many captured leads successfully move to a scheduled meeting.
-
-### Common Challenges and Solutions
-
-### Challenge: Visitors Won't Share Information
-
-**Problem**: Anonymous users refuse to provide contact details even after helpful conversation.
-
-**Solutions**:
-
-- Strengthen value proposition at conversion point
-- Offer additional resources in exchange for contact information
-- Provide alternative contact methods (phone, email, text)
-- Reduce information requested to minimum necessary
-
-### Challenge: Low-Quality Leads
-
-**Problem**: Conversions happen but leads aren't qualified or serious.
-
-**Solutions**:
-
-- [Improve qualification questions](/ai-chat/ai-chat-client-acquisition) in conversation
-- Implement [lead scoring](/ai-chat/ai-chat-client-acquisition) based on conversation content
-- Set up additional qualification steps before consultation
-
-## Advanced Features
-
-### Consistent Experience Across Visits
-
-If a potential client starts an intake conversation on their phone but wants to finish it later on a desktop, maintaining that context ensures they don't have to start over. This consistency reinforces your firm's professional image and respects the client's time.
-
-### Firm Workflow Integration
-
-Captured lead data can be reviewed by your intake team and integrated into your firm's existing client management workflows, ensuring a smooth handoff from the automated chat to a human team member.
-
-## Next Steps
-
-Your anonymous-to-authenticated flow is now designed to convert more visitors into clients:
-
-1. **[Configure your conversation flow](/ai-chat/ai-chat-client-acquisition)** with clear stage transitions
-2. **[Set up tracking and analytics](/ai-chat/ai-chat-client-acquisition)** to monitor performance
-3. **Test and optimize** based on real user behavior
-4. **Scale your success** across all marketing channels
+- Build your template: [Intake Templates](/features/intake-templates).
+- Wire up your widget: [Install the Chat Widget](/ai-chat/install-chat-widget).
+- Set your triage policy: [Review and Triage Client Intakes](/features/review-and-triage-intake).
 
 ---
 
-## Ready to Transform Your Client Acquisition?
-
-Implement this anonymous-to-authenticated flow to capture more leads, qualify better prospects, and convert more visitors into paying clients. [Start your setup](https://dashboard.blawby.com) and begin converting anonymous visitors into valuable client relationships today.
+Ready to convert more visitors into paying clients? [Start your setup.](https://ai.blawby.com/register)

--- a/src/data/solutions/ai-chat/modern-intake-flow.mdx
+++ b/src/data/solutions/ai-chat/modern-intake-flow.mdx
@@ -100,7 +100,7 @@ If your template has a **consultation fee**, the Stripe payment card renders inl
 
 <DocPlaceholder
   kind="screenshot"
-  src="/docs/intake/four-stage-flow.png"
+  src="/media/docs/intake/four-stage-flow.png"
   description="Annotated chat screenshot showing all four stages — engagement, trust building, qualification, authentication + fee — in one continuous thread."
 />
 

--- a/src/data/solutions/business-strategy/future-proof-revenue.mdx
+++ b/src/data/solutions/business-strategy/future-proof-revenue.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Future-Proof Revenue: Scaling Your Legal Practice"
 metaTitle: "Future-Proof Revenue for Law Firms | Blawby"
-desc: "Build more predictable law firm revenue with flat fees, payment plans, and automated billing practices."
+desc: "Build predictable law firm revenue with Blawby's four billing types — flat fee, hourly, retainer, contingency — plus matter-driven automated invoicing."
 image: "https://imagedelivery.net/Frxyb2_d_vGyiaXhS5xqCg/527f8451-2748-4f04-ea0f-805a4214cd00/public"
 author: "Paul Chris Luke"
 authorImage: "/images/logo.png"
@@ -9,153 +9,155 @@ category: "business-strategy"
 contentType: "article"
 order: 10
 createdAt: "01/20/2024"
-updatedAt: "01/20/2024"
+updatedAt: "05/07/2026"
+lastVerified: "05/07/2026"
 tags:
   - Revenue-Optimization
   - Flat-Fees
-  - Payment-Plans
-  - Automated-Billing
+  - Retainers
+  - Hourly-Billing
+  - Contingency
   - Cash-Flow
   - Practice-Management
 keywords:
   - Law firm revenue
-  - Payment plans
   - Flat fees
-  - Automated billing
+  - Retainers
+  - Hourly billing
+  - Contingency
+  - Automated invoicing
   - Cash flow management
 targetAudience: "practice-owners"
 searchIntent: "commercial"
 primaryKeyword: "law firm revenue"
-secondaryKeywords: ["payment plans", "flat fees", "automated billing"]
-summary: "Transform your law firm's revenue with flat fees, payment plans, and automated billing for predictable cash flow."
+secondaryKeywords: ["retainer billing", "flat fees", "automated invoicing"]
+summary: "Use the four billing types Blawby supports — flat, hourly, retainer, contingency — and matter-driven invoicing to make your firm's cash flow predictable."
 schemaType: "Article"
 faq:
-  - question: "How do payment plans improve law firm revenue?"
-    answer: "Payment plans make legal services affordable, increase client acquisition, and provide predictable monthly revenue streams for your practice."
-  - question: "Are flat fees better than hourly billing?"
-    answer: "Flat fees provide predictable costs for clients and guaranteed revenue for firms, making them ideal for routine legal services and document preparation."
+  - question: "Which billing types does Blawby support?"
+    answer: "Flat fee, hourly, retainer (with balance draws), and contingency. Each can be set per matter and per engagement."
+  - question: "Are retainers handled in trust?"
+    answer: "Yes. When your practice is configured for trust routing, client retainer payments deposit into your trust account; processing fees are charged separately to a card linked to your operating account."
+  - question: "How does automated invoicing work?"
+    answer: "From a matter, Blawby generates an invoice from logged time and expenses with one click. The client receives a hosted Stripe payment link; the invoice marks paid automatically when payment clears."
 noindex: false
 ---
 
-# How to Future-Proof Your Law Firm's Revenue: Flat Fees, Payment Plans, and Automated Billing
+# How to Future-Proof Your Law Firm's Revenue: Flat Fees, Retainers, Hourly Billing, and Automated Invoicing
 
 ## Why Predictable Revenue Matters for Law Firms
 
-Unpredictable cash flow is one of the biggest headaches for solo and small firm attorneys. Clients want flexibility, but you need to keep the lights on and your team paid. The good news? You can have both—by combining flat fees, payment plans, and automated billing features.
+Unpredictable cash flow is one of the biggest headaches for solo and small firm attorneys. Clients want clarity on cost, you need to keep the lights on, and the work itself rarely fits the same shape twice. The answer isn't picking *one* billing model — it's pairing the right one with each matter and letting the platform handle the rest.
 
-For many law firms, the traditional model of hourly billing and chasing down payments is not only time-consuming but also stressful. It can lead to cash flow gaps, client frustration, and administrative overload. By modernizing your approach, you can create a more stable, client-friendly, and efficient practice.
+Blawby supports four billing types out of the box. Each can be applied per matter and per engagement letter, with rates set on the firm or on the individual user (attorney vs. admin). Combined with automated, matter-driven invoicing, this gets you a billing flow that respects how you actually practice without burning your team's evenings on admin.
+
+## The Four Billing Types Blawby Supports
+
+| Billing type | Best for | Where it lives in the product |
+|---|---|---|
+| **Flat fee** | Predictable scope: wills, uncontested divorce, traffic, simple LLC formation | Matter billing settings + flat-fee line items on invoices |
+| **Hourly** | Variable-scope litigation, transactional work | Time entries with attorney/admin rates; invoice generation pulls unbilled time |
+| **Retainer** | Ongoing representation, deposits against future work | Retainer balance per matter; invoices draw from the balance and refill on top-up |
+| **Contingency** | Personal injury, certain employment matters | Contingency percentage on the engagement; invoiced on settlement |
+
+You're not locked in. A matter can switch billing types as it evolves — for example, a divorce that starts uncontested (flat fee) and moves into litigation (hourly).
 
 ## Flat Fees: Simplicity Clients Love
 
-Flat fees are more than a trend—they're a client expectation. Offering flat fees for common matters (like uncontested divorces, wills, or traffic tickets) gives clients cost certainty and reduces billing disputes. For your firm, it means less time tracking and more time focused on client work.
-
-### What Are Flat Fees?
-
-A flat fee is a set price for a specific legal service, regardless of the time it takes to complete. This model is especially effective for predictable, repeatable tasks. Clients appreciate knowing exactly what they'll pay, and you benefit from streamlined billing and fewer disputes.
+A flat fee is a set price for a defined scope, regardless of the time it takes. It's especially effective for predictable, repeatable work. Clients appreciate cost certainty; you benefit from streamlined billing and fewer disputes.
 
 ### How to Get Started with Flat Fees
 
-- **Identify your most predictable services:** Review your case history to find matters with consistent scope and effort. For example, if you regularly handle simple estate plans or uncontested divorces, these are ideal candidates for a flat-fee approach.
-- **Set clear, all-inclusive prices:** Factor in your time, overhead, and any potential complications. Be transparent about what is included and what is not. When a client comes to you for a straightforward matter, being able to say, "This will cost $1,200, start to finish," builds trust and makes the decision easier for them.
-- **Communicate exactly what's included (and what's not):** Use engagement letters and invoices to spell out the scope. This reduces misunderstandings and sets clear expectations. If a case becomes more complex—say, a divorce that starts uncontested but later requires litigation—your agreement can specify how billing will adapt, so there are no surprises.
-- **Use your billing software to generate flat-fee invoices in a few clicks:** Modern platforms make it easy to create, send, and track flat-fee invoices, so you spend less time on admin and more on client work.
+- **Identify your most predictable services.** Review your case history to find matters with consistent scope and effort.
+- **Set clear, all-inclusive prices.** Factor in your time, overhead, and likely complications. Be transparent about what's in and out of scope.
+- **Spell out the boundary in the engagement letter.** Blawby's engagement step lets you fix the scope; if a case becomes more complex, your terms can specify how billing adapts.
+- **Generate flat-fee invoices in a few clicks** from the matter, then track payment in real time.
 
-> **Tip:** Flat fees can be combined with other billing models. For example, you might offer a flat fee for initial consultation and hourly rates for additional work.
+> **Tip:** Flat fees mix well with hourly billing. Quote a flat fee for a defined consultation, then switch to hourly if the work expands beyond the quoted scope.
 
 [Learn more about legal pricing strategies](/pricing)
 
-## Payment Plans: Make Legal Help Accessible (and Get Paid Faster)
+## Retainers: Steady Cash, Earned as You Work
 
-Not every client can pay a large bill up front. Payment plans let you break invoices into manageable chunks, making your services accessible to more people—while improving your own collection rate.
+A retainer is a deposit a client pays up front against future work. Blawby tracks the retainer balance on the matter, and each invoice draws against it; you can prompt the client to top up when the balance runs low.
 
-### Why Offer Payment Plans?
+### Why Retainers Work
 
-- **Increase access to legal services:** More clients can afford your help when payments are spread out. For instance, if you offer a $3,000 flat fee for a criminal defense case, you might structure it as $1,000 down and $500/month for four months. This approach opens the door to clients who otherwise couldn't afford representation, while ensuring you receive steady, predictable payments.
-- **Reduce accounts receivable:** Clients are less likely to fall behind when payments are predictable and automated. When your system automatically sends reminders and processes payments, you spend less time chasing overdue bills.
-- **Build trust and loyalty:** Flexible payment options show you understand your clients' needs. Clients appreciate knowing they can get the help they need without a huge upfront cost, and your firm benefits from a more reliable cash flow.
+- **Up-front cash.** You collect before the work, which smooths cash flow.
+- **Predictable client behavior.** Clients are more committed when they've put money down.
+- **Trust-safe by default.** With trust routing configured, retainer dollars land in your trust account and only move to operating once they're earned.
 
-### How to Offer Payment Plans
+### How to Use Retainers in Blawby
 
-- **Decide which services are eligible:** Flat-fee matters, retainers, or even large hourly bills can be split into installments. For example, you might offer payment plans for estate planning, family law, or business formation services.
-- **Set minimums for down payments and installment amounts:** Ensure each payment covers your costs and reduces risk. A reasonable down payment demonstrates client commitment and helps cover initial expenses.
-- **Use your billing platform to schedule automatic payments and reminders:** Automation reduces manual follow-up and ensures timely payments. Clients receive reminders before each installment is due, making it easy for them to stay on track.
-- **Track outstanding balances and upcoming payments in your dashboard:** Stay on top of your cash flow and follow up only when necessary. If a client misses a payment, your system can alert you so you can address it promptly and professionally.
+- **Set the retainer amount on the engagement letter.** Make the deposit a condition of representation.
+- **Log time and expenses against the matter** as you work.
+- **Generate an invoice from the unbilled summary** — the invoice draws from the retainer balance.
+- **Top up when low.** Send a payment request directly from the matter to refill the balance.
 
-[See how payment processing works for law firms](/payments/accepting-payments)
+[Read the IOLTA Compliance Guide](/compliance/iolta-compliance) for how trust dollars and operating fees stay separate.
 
-### Step-by-Step: Setting Up a Payment Plan
+## Hourly Billing: Made Easier by Time Tracking Tied to Matters
 
-1. **Discuss payment options during intake:** Let clients know you offer payment plans and explain the terms. This conversation can be a relief for clients who are worried about affording legal help.
-2. **Draft a clear payment agreement:** Specify the total amount, payment schedule, due dates, and consequences for missed payments. This clarity helps avoid misunderstandings down the road.
-3. **Collect a down payment:** This shows commitment and covers initial costs.
-4. **Automate the rest:** Use your billing software to send invoices and reminders automatically, so you don't have to remember each due date.
-5. **Monitor and adjust:** If a client misses a payment, your system should alert you so you can follow up promptly and keep the relationship positive.
+Hourly billing fights you when time is logged in spreadsheets and copied into invoices manually. Blawby ties time tracking to the matter directly:
 
-## Automated Billing: Less Admin, More Results
+- Time entries are logged on the matter with start/end or duration.
+- Each entry uses the rate appropriate for the user — attorney or admin — set on the firm or per user.
+- The matter's **Billing tab** shows an unbilled summary: total billable hours and unbilled expenses.
+- One click generates an invoice that pulls those entries as line items.
 
-Manual invoicing and reminders eat up valuable time. Automated billing features let you:
+The result: less time chasing what was logged where, and clean invoices clients can read.
 
-- Schedule invoices to go out on specific dates
-- Send automatic payment reminders (no more awkward follow-ups)
-- Accept multiple payment methods (credit card, ACH/bank transfer)
-- Track payments and outstanding balances in real time
+## Contingency: When the Matter Is the Investment
 
-### Why Automate Billing?
+For personal injury, certain employment cases, and other matters where the firm fronts the work, the engagement letter records the contingency percentage and any costs that come off the top. Time and expenses still log to the matter for internal visibility, but the invoice issues at settlement.
 
-- **Save time:** Reduce manual data entry and follow-up. For example, a mid-sized firm handling ongoing matters can set up monthly invoices and reminders, freeing up staff to focus on client service instead of collections.
-- **Get paid faster:** Automated reminders and easy payment options mean clients pay sooner. When clients receive a reminder three days before and after the due date, late payments drop dramatically.
-- **Reduce errors:** Automation ensures accuracy and consistency, so you don't have to worry about missed invoices or incorrect amounts.
-- **Improve client experience:** Clients appreciate clear, timely communication and flexible payment options. When paying is easy, clients are more likely to pay on time and recommend your firm to others.
+## Automated Invoicing: Less Admin, More Results
+
+Manual invoicing eats time that could go to client work. Blawby's invoicing flow is built around the matter:
+
+- **One-click invoice generation** from unbilled time, expenses, flat-fee line items, or retainer draws.
+- **Hosted payment links** so clients can pay by card or ACH without an account.
+- **Real-time status tracking** — Draft → Sent → Paid (or Overdue), all visible on the matter.
+- **Email + push notifications** when an invoice is sent, viewed, or paid.
+
+### Why Automate
+
+- **Save time.** Stop building invoices from scratch.
+- **Get paid faster.** Reminders go out automatically; payment links are one tap.
+- **Reduce errors.** Pulling from the matter's logged time and expenses removes a transcription step.
+- **Better client experience.** Clear, timely communication and a no-friction pay flow.
 
 [Explore invoicing best practices](/payments/invoicing)
 
-### How to Implement Automated Billing
+## Compliance and Trust Accounting: Built In, Not Bolted On
 
-- **Choose a platform with robust automation features:** Look for scheduled invoicing, recurring payments, and automated reminders.
-- **Set up templates for common services:** Pre-fill details for flat fees, retainers, or payment plans, so you can send invoices in seconds.
-- **Enable multiple payment methods:** Make it easy for clients to pay by card or ACH/bank transfer.
-- **Monitor your dashboard:** Track which invoices are paid, pending, or overdue at a glance, so you always know where your cash flow stands.
+Compliance friction is what kills most legal billing setups. Blawby handles it like this:
 
-## Compliance and Trust Accounting: Reducing Friction, Supporting Your Practice
-
-Compliance isn't just about following rules—it's about removing the pain points that slow your team down and create risk. Many law firms, regardless of size, face friction in their billing and trust accounting workflows:
-
-- **Manual reconciliation headaches:** Matching payments to the right accounts and matters can eat up hours each month.
-- **Worry about accidental commingling:** Even experienced teams can make mistakes when moving funds between trust and operating accounts.
-- **Unclear audit trails:** When payment records are scattered or incomplete, audits become stressful and time-consuming.
-- **Fee deduction confusion:** Some processors deduct fees from client funds, creating compliance headaches and extra work.
-
-Blawby is designed to support compliance and reduce these friction points for any law office:
-
-- **Automatic separation of earned and unearned funds:** Payments are routed to the correct accounts, so you don't have to worry about manual sorting or accidental commingling.
-- **No fees deducted from trust:** Processing and platform fees are always billed to your operating account, never from client funds, so you stay compliant by default.
-- **Clear, searchable audit trails:** Every transaction is logged and easy to review, making audits and reconciliations faster and less stressful.
+- **Automatic separation of earned and unearned funds.** Trust-eligible payments route to your trust account; the platform never deducts fees from those dollars.
+- **No fees from trust.** Processing and platform fees are charged separately to the operating-account card you connect at setup.
+- **Searchable audit trails.** Every transaction logs on the matter with timestamps, amounts, and the user who made the change.
 
 [Read about IOLTA compliance](/compliance/iolta-compliance)
 
-## What Happens When You Combine All Three?
+## What Happens When You Combine All Four
 
-Firms that use flat fees, payment plans, and automated billing together:
+Firms that treat the four billing types as a toolkit — choosing the right one per matter, with retainer top-ups for ongoing work and automated invoicing across all of them — get:
 
-- Get paid faster and more consistently
-- Spend less time on admin and more on client work
-- Reduce billing disputes and improve client satisfaction
-- Make legal services more accessible to a wider range of clients
-- Stay compliant with trust accounting and industry regulations
-
-### Unified Strategy: Bringing It All Together
-
-When you bring these features together, you create a workflow where clients know exactly what they'll pay, can choose a payment plan that fits their budget, and receive timely reminders and easy payment options. Your team spends less time on admin, your cash flow becomes more predictable, and compliance is built into every transaction. Whether you're helping a family with an estate plan or guiding a business through formation, this approach lets you focus on what matters most: delivering great legal service.
+- More predictable monthly revenue.
+- Less time on admin per matter.
+- Fewer billing disputes (because scope and rates are explicit in the engagement).
+- Cleaner trust-account compliance, by default.
 
 ## Comprehensive Best Practices for Revenue Strategy
 
-- **Practical implementation:** Beyond individual features, focus on how flat fees and payment plans work together to stabilize monthly cash flow.
-- **Compliance depth:** Ensure your trust accounting workflows are automated to prevent commingling and simplify future audits.
-- **Unified approach:** Integrate these billing models into your initial intake conversation to set clear expectations and build client trust from day one.
+- **Pick the billing type at the engagement step**, not after work has started. Trying to switch mid-stream creates client friction.
+- **Log time the day it happens**, even on flat-fee matters. You'll see scope creep before it eats your margin.
+- **Use retainer top-ups as a workflow**, not an apology. Build them into your matter cadence.
+- **Reconcile trust monthly.** Blawby gives you the records; the discipline is yours.
 
 ## Ready to Make Your Revenue Predictable?
 
-Start using flat fees, payment plans, and automated billing to take control of your firm's cash flow. The right tools make it easy to set up, track, and get paid—without extra admin. [See how our platform can help you simplify billing and boost your bottom line.](https://ai.blawby.com/register)
+Start using flat fees, retainers, hourly billing, and contingency the way each matter actually requires — and let matter-driven invoicing handle the admin. [See how Blawby can help your firm simplify billing and boost your bottom line.](https://ai.blawby.com/register)
 
 ---
 

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -66,6 +66,17 @@ export type Frontmatter = {
    * Surfaced in the UI; CI can flag docs older than 90 days.
    */
   lastVerified?: string;
+
+  // Hierarchy Metadata
+  /**
+   * Optional sub-group label within the doc's category. Items sharing the
+   * same `group` value collapse under a single sidebar header (e.g. "Intake",
+   * "Matters", "Engagements"). Drives the breadcrumb's middle segment too.
+   * Leave unset for flat categories (Quick Start, Reference).
+   */
+  group?: string;
+  /** Optional ordering for the sub-group itself within its category. */
+  groupOrder?: number;
 };
 
 // ─── Parser ───────────────────────────────────────────────────────────────────

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -59,6 +59,13 @@ export type Frontmatter = {
   timeToComplete?: string;
   /** Follow-up content slugs for docs flows */
   nextSteps?: string[];
+
+  // Maintenance Metadata
+  /**
+   * Date the doc was last verified against the live product (MM/DD/YYYY or ISO).
+   * Surfaced in the UI; CI can flag docs older than 90 days.
+   */
+  lastVerified?: string;
 };
 
 // ─── Parser ───────────────────────────────────────────────────────────────────
@@ -75,6 +82,8 @@ export function parseFrontmatter(source: string): Frontmatter {
 
     if (parsed.createdAt) parsed.createdAt = normalizeDate(parsed.createdAt);
     if (parsed.updatedAt) parsed.updatedAt = normalizeDate(parsed.updatedAt);
+    if (parsed.lastVerified)
+      parsed.lastVerified = normalizeDate(parsed.lastVerified);
 
     return parsed as Frontmatter;
   } catch (e) {

--- a/src/utils/section-label.ts
+++ b/src/utils/section-label.ts
@@ -1,0 +1,18 @@
+/**
+ * Convert a section slug like "quick-start" or "ai-chat" into a Title-Case
+ * label matching Vercel's docs sidebar typography ("Quick Start", "AI Chat").
+ *
+ * Used by both server components (breadcrumb derivation) and the client-side
+ * sidebar nav, so it lives here as a plain utility module — no "use client".
+ */
+export function formatSectionLabel(raw: string): string {
+  const cleaned = raw.replace(/[-_]/g, " ").trim();
+  return cleaned
+    .split(/\s+/)
+    .map((word) => {
+      if (word.toLowerCase() === "ai") return "AI";
+      if (word.length === 0) return word;
+      return word[0].toUpperCase() + word.slice(1).toLowerCase();
+    })
+    .join(" ");
+}


### PR DESCRIPTION
## Summary

Rewrites the docs site around the actual product surface (intake templates, matters, engagements, Stripe Connect, AI intent modes), then restructures the layout to match Vercel's docs IA — hierarchical sidebar, dynamic breadcrumbs, and a single uniform background across header / sidebar / main / footer.

Two commits:

1. **9630aed** — replace generic legal-ops MDX with feature-specific docs grounded in the reference codebase. Add `<Callout>` and `<DocPlaceholder>` MDX components plus a `lastVerified` frontmatter field. Fix three high-risk docs that misrepresented the product (fictional API endpoints, fictional widget URL, unsupported "payment plans" claim).
2. **2e344ec** — Vercel-style sidebar hierarchy via `group`/`groupOrder` frontmatter; recursive nested rendering (section → sub-group → leaves). Dynamic breadcrumbs derived from `origin → category → group → title` with no hardcoded IA labels. Header / footer / sidebar / body unified to `bg-white dark:bg-black` (matches Vercel's `--ds-background-100 = lab(0%)` for dark mode); borders between surfaces removed. Sticky sidebar inside an `mx-auto max-w-[1400px]` container so layout shifts toward center on wide viewports. Inline breadcrumb row replaces the sticky sub-header bar. "Last verified" meta moved to top with separator. Hydration warnings silenced for Logo SVG paths (Dark Reader) and Shiki code blocks.

## Changes

- **Content (16 docs)** — quick-start, features, reference, lessons (payouts, invoicing, accepting-payments), and ai-chat solutions all rewritten to match the real product (intake templates with required vs. enrichment fields and conditional logic, matter tabs and time tracking, structured engagement letters, Stripe Connect onboarding, 18-language widget, four AI intent modes).
- **3 new anchor docs** — `intake-templates`, `matters-overview`, `engagements-overview`.
- **Components** — `Callout` (note/tip/warning/important variants) and `DocPlaceholder` (screenshot/video/diagram stand-ins). Recursive nested sidebar with `SidebarSubGroup`, expand-state via path keys.
- **API reference** — replaced fictional `/api/v1/*` endpoints and SDK with an honest "what ships today / what's on the roadmap" page.
- **Frontmatter** — added `group`, `groupOrder`, `lastVerified` fields (loose; backward-compatible).
- **Placeholder media** — staged at `public/media/docs/` with a checklist file for the design team.

## Test plan

- [x] `pnpm run typecheck` — no errors
- [x] `pnpm run build` — 47 routes, all SSG
- [x] `node scripts/check-internal-links.mjs` — pass
- [x] `node scripts/check-seo.mjs` — 33 indexable pages, 0 warnings
- [x] `node scripts/check-legacy-paths.mjs` — pass
- [x] Visual: light mode, dark mode (forced), 1280px and 1920px widths verified via Playwright against Vercel's `/docs/fundamentals/infrastructure`

## Out of scope (follow-ups noted in placeholder checklist)

- Capturing real screenshot/video assets for the 23 `<DocPlaceholder>` references in `public/media/docs/PLACEHOLDER-CHECKLIST.md`
- Manual dark-mode toggle (Tailwind class strategy + UI control) — currently driven by `prefers-color-scheme`

🤖 Generated with [Claude Code](https://claude.com/claude-code)