### PR TITLE
fix: deploy Pages from out/ and split worker config (closes #16)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,7 +71,7 @@ jobs:
             --branch=master
 
       - name: Deploy Worker
-        run: pnpm exec wrangler deploy
+        run: pnpm exec wrangler deploy --config wrangler.worker.toml
 
       - name: Lighthouse CI (production)
         uses: treosh/lighthouse-ci-action@v12

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,2 +1,2 @@
 name = "blawby-marketing-frontend"
-pages_build_output_dir = ".next"
+pages_build_output_dir = "out"

--- a/wrangler.worker.toml
+++ b/wrangler.worker.toml
@@ -1,0 +1,15 @@
+name = "blawby-marketing-backend"
+main = "src/workers/search.ts"
+compatibility_date = "2026-04-29"
+compatibility_flags = ["nodejs_compat"]
+
+[ai]
+binding = "AI"
+
+[vars]
+AI_SEARCH_NAME = "blawby-autorag-instance"
+
+[[d1_databases]]
+binding = "SUPPORT_DB"
+database_name = "support"
+database_id = "e2d54e53-bad8-4927-9ed7-d401d5488c6a"


### PR DESCRIPTION
## Summary
- Point Pages at `out/` (the actual static-export directory produced by `output: "export"`) instead of `.next/`, which contains a 40.8 MiB webpack cache file that exceeds Cloudflare Pages' 25 MiB per-file limit.
- Restore the search worker config in a separate `wrangler.worker.toml`; the previous fix in [04a672c](https://github.com/Blawby/blawby-cloudflare-marketing/commit/04a672c) wiped it out, which broke the `Deploy Worker` CI step (`It looks like you've run a Workers-specific command in a Pages project`).
- `deploy.yml` now passes `--config wrangler.worker.toml` to the worker deploy step. The Pages step is unchanged — it already passes `out` as an explicit path.

Closes [#16](https://github.com/Blawby/blawby-cloudflare-marketing/issues/16).

## Test plan
- [ ] CI `Deploy to Cloudflare Pages and Worker` workflow succeeds end-to-end on this branch (both Pages and Worker steps).
- [ ] Manual `npx wrangler pages deploy --project-name blawby-marketing-frontend` no longer errors with the 25 MiB limit (now defaults to `out/`).
- [ ] Manual `npx wrangler deploy --config wrangler.worker.toml` deploys the search worker with AI + D1 bindings intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow and build output configuration.
  * Added backend infrastructure with new service integrations and database bindings.
  * Enhanced CI/CD pipeline for improved deployment handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->